### PR TITLE
Include all number dtypes as inputs

### DIFF
--- a/lazypredict/Supervised.py
+++ b/lazypredict/Supervised.py
@@ -261,9 +261,7 @@ class LazyClassifier:
             X_train = pd.DataFrame(X_train)
             X_test = pd.DataFrame(X_test)
 
-        numeric_features = X_train.select_dtypes(
-            include=["int64", "float64", "int32", "float32"]
-        ).columns
+        numeric_features = X_train.select_dtypes(include=[np.number]).columns
         categorical_features = X_train.select_dtypes(include=["object"]).columns
 
         categorical_low, categorical_high = get_card_split(
@@ -499,9 +497,7 @@ class LazyRegressor:
             X_train = pd.DataFrame(X_train)
             X_test = pd.DataFrame(X_test)
 
-        numeric_features = X_train.select_dtypes(
-            include=["int64", "float64", "int32", "float32"]
-        ).columns
+        numeric_features = X_train.select_dtypes(include=[np.number]).columns
         categorical_features = X_train.select_dtypes(include=["object"]).columns
 
         categorical_low, categorical_high = get_card_split(


### PR DESCRIPTION
While doing some experiments with the library, my inputs were not accepted and I was getting 0 features found errors. I did some investigation and discovered a bug: My dtypes were all uint8 but it is not listed in the selected dtypes.

Previously only these dtypes are allowed as inputs: `["int64", "float64", "int32", "float32"]`. However, there are more than that. Official pandas documentation [states that](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.select_dtypes.html) to select all number dtypes, `np.number` can be used. This PR implements this.

Thanks.