### PR TITLE
Remove py from dev dependency list

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -36,7 +36,6 @@ pbr==5.4.5
 plotly==4.14.3
 pluggy==0.13.1
 prettytable==0.7.2
-py==1.9.0
 pyparsing==2.4.7
 pyperclip==1.8.0
 pytest==5.4.3


### PR DESCRIPTION
Removing because it shouldn't be used anymore, as the official py documentation says: "NOTE: this library is in maintenance mode and should not be used in new code."