### PR TITLE
Updated precision of output metrics to 4

### DIFF
--- a/lazypredict/Supervised.py
+++ b/lazypredict/Supervised.py
@@ -30,8 +30,8 @@ import xgboost
 import lightgbm
 
 warnings.filterwarnings("ignore")
-pd.set_option("display.precision", 2)
-pd.set_option("display.float_format", lambda x: "%.2f" % x)
+pd.set_option("display.precision", 4) 
+pd.set_option("display.float_format", lambda x: "%.4f" % x)
 
 removed_classifiers = [
     "ClassifierChain",


### PR DESCRIPTION
## Problem
Precision value= 2 involves round-off of many decimal values making the multiple algorithms show same score. When the percentage is mentioned, no decimal point can be mentioned from the prediction, which raises issues when the work is mentioned in documents. Also, these close scores make algorithm selection for hyperparameter tuning difficult.
## Screenshot: 
I got 5 algorithms with same accuracy 0.86 on using *LazyClassifier*.
![Metric Score for Software Reliability dataset](https://user-images.githubusercontent.com/76547274/208733009-03a5eb86-263c-49bd-9539-20266225bd3f.jpeg)


## Updates Made: I have updated the precision value to 4.
