### PR TITLE
Fix #441 and #442, changed sparse keyword in OneHotEncoder

### DIFF
--- a/lazypredict/Supervised.py
+++ b/lazypredict/Supervised.py
@@ -95,7 +95,7 @@ numeric_transformer = Pipeline(
 categorical_transformer_low = Pipeline(
     steps=[
         ("imputer", SimpleImputer(strategy="constant", fill_value="missing")),
-        ("encoding", OneHotEncoder(handle_unknown="ignore", sparse=False)),
+        ("encoding", OneHotEncoder(handle_unknown="ignore", sparse_output=False)),
     ]
 )
 


### PR DESCRIPTION
Fix issue #441 / #442 deprecated keyword sparse changed to sparse_output

The keyword simply changed its name from `sparse` to `sparse_output`.