### PR TITLE
Freeze third level dependency markupsafe for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tqdm
 joblib
 lightgbm
 xgboost
+markupsafe <=2.1.4


### PR DESCRIPTION
Limit markupsafe to 2.1.4, as 2.1.5 fails on import