### PR TITLE
fix: change keyword sparse to sparse_output

### DIFF
--- a/lazypredict/Supervised.py
+++ b/lazypredict/Supervised.py
@@ -95,7 +95,7 @@ numeric_transformer = Pipeline(
 categorical_transformer_low = Pipeline(
     steps=[
         ("imputer", SimpleImputer(strategy="constant", fill_value="missing")),
-        ("encoding", OneHotEncoder(handle_unknown="ignore", sparse=False)),
+        ("encoding", OneHotEncoder(handle_unknown="ignore", sparse_output==False)),
     ]
 )
 

--- a/lazypredict/utils.py
+++ b/lazypredict/utils.py
@@ -7,7 +7,7 @@ numeric_transformer = Pipeline(
 categorical_transformer_low = Pipeline(
     steps=[
         ("imputer", SimpleImputer(strategy="constant", fill_value="missing")),
-        ("encoding", OneHotEncoder(handle_unknown="ignore", sparse=False)),
+        ("encoding", OneHotEncoder(handle_unknown="ignore", sparse_output=False)),
     ]
 )
 


### PR DESCRIPTION
The sparse keywork has been renamed to sparse_output, without this fix the error `TypeError: OneHotEncoder.init() got an unexpected keyword argument 'sparse` will be returned.

More details in the scikit-learn documentation: https://scikit-learn.org/stable/modules/generated/sklearn.pre
processing.OneHotEncoder.html