### PR TITLE
Add documentation structure and examples for Lazy Predict

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,6 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath(".."))
-# sys.path.insert(0, os.path.abspath('..\lazypredict'))
-# print(sys.path)
 import lazypredict
 
 # -- General configuration ---------------------------------------------
@@ -34,7 +32,13 @@ import lazypredict
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.githubpages",
+    "myst_parser"
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -42,15 +46,14 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = [".rst", ".md"]
 
 # The master toctree document.
 master_doc = "index"
 
 # General information about the project.
 project = u"Lazy Predict"
-copyright = u"2022, Shankar Rao Pandala"
+copyright = u"2022-2025, Shankar Rao Pandala"
 author = u"Shankar Rao Pandala"
 
 # The version info for the project you're documenting, acts as replacement
@@ -67,7 +70,7 @@ release = lazypredict.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -86,13 +89,16 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "default"
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
 # documentation.
-#
-# html_theme_options = {}
+html_theme_options = {
+    'navigation_depth': 4,
+    'titles_only': False,
+    'logo_only': False,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -156,7 +162,23 @@ texinfo_documents = [
         u"Lazy Predict Documentation",
         author,
         "lazypredict",
-        "One line description of project.",
-        "Miscellaneous",
+        "Automated machine learning model selection.",
+        "Machine Learning",
     ),
 ]
+
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_preprocess_types = False
+napoleon_type_aliases = None
+napoleon_attr_annotations = True

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,128 @@
+========
+Examples
+========
+
+This page contains detailed examples of how to use Lazy Predict in various scenarios.
+
+Classification Example
+--------------------
+
+Basic Classification
+~~~~~~~~~~~~~~~~~~~
+
+Here's a basic example using the breast cancer dataset:
+
+.. code-block:: python
+
+    from lazypredict.Supervised import LazyClassifier
+    from sklearn.datasets import load_breast_cancer
+    from sklearn.model_selection import train_test_split
+
+    # Load data
+    data = load_breast_cancer()
+    X = data.data
+    y = data.target
+
+    # Split data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=123)
+
+    # Create classifier
+    clf = LazyClassifier(verbose=0, ignore_warnings=True, custom_metric=None)
+    
+    # Fit and get models
+    models, predictions = clf.fit(X_train, X_test, y_train, y_test)
+    print(models)
+
+Classification with Custom Metric
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use custom metrics for model evaluation:
+
+.. code-block:: python
+
+    from sklearn.metrics import f1_score
+
+    def custom_f1(y_true, y_pred):
+        return f1_score(y_true, y_pred, average='weighted')
+
+    clf = LazyClassifier(verbose=0, ignore_warnings=True, custom_metric=custom_f1)
+    models, predictions = clf.fit(X_train, X_test, y_train, y_test)
+
+Regression Example
+----------------
+
+Basic Regression
+~~~~~~~~~~~~~~
+
+Here's an example using the diabetes dataset:
+
+.. code-block:: python
+
+    from lazypredict.Supervised import LazyRegressor
+    from sklearn.datasets import load_diabetes
+    from sklearn.model_selection import train_test_split
+
+    # Load data
+    diabetes = load_diabetes()
+    X = diabetes.data
+    y = diabetes.target
+
+    # Split data
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=123)
+
+    # Create and fit regressor
+    reg = LazyRegressor(verbose=0, ignore_warnings=True, custom_metric=None)
+    models, predictions = reg.fit(X_train, X_test, y_train, y_test)
+    print(models)
+
+Working with Pandas DataFrames
+---------------------------
+
+Lazy Predict works seamlessly with pandas DataFrames:
+
+.. code-block:: python
+
+    import pandas as pd
+    
+    # Your DataFrame
+    df = pd.DataFrame(X, columns=diabetes.feature_names)
+    
+    # Split features and target
+    X = df
+    y = pd.Series(diabetes.target)
+    
+    # Rest remains the same
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+    reg = LazyRegressor(verbose=0, ignore_warnings=True)
+    models, predictions = reg.fit(X_train, X_test, y_train, y_test)
+
+Using with MLflow
+---------------
+
+Lazy Predict integrates with MLflow for experiment tracking:
+
+.. code-block:: python
+
+    import os
+    os.environ['MLFLOW_TRACKING_URI'] = 'sqlite:///mlflow.db'
+
+    # MLflow tracking will be automatically enabled
+    reg = LazyRegressor(verbose=0, ignore_warnings=True)
+    models, predictions = reg.fit(X_train, X_test, y_train, y_test)
+    # All metrics will be logged to MLflow automatically
+
+Getting Model Objects
+------------------
+
+You can access the trained model objects:
+
+.. code-block:: python
+
+    # Get all trained models
+    model_dictionary = reg.provide_models(X_train, X_test, y_train, y_test)
+
+    # Access specific model
+    random_forest = model_dictionary['RandomForestRegressor']
+    
+    # Make predictions with specific model
+    predictions = random_forest.predict(X_test)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,20 +1,65 @@
-Welcome to Lazy Predict's documentation!
-======================================
+Welcome to Lazy Predict
+==================
+
+Lazy Predict helps build a lot of basic models without much code and helps understand which models work better without any parameter tuning.
+
+.. image:: https://img.shields.io/pypi/v/lazypredict.svg
+   :target: https://pypi.python.org/pypi/lazypredict
+
+.. image:: https://readthedocs.org/projects/lazypredict/badge/?version=latest
+   :target: https://lazypredict.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
+.. image:: https://pepy.tech/badge/lazypredict
+   :target: https://pepy.tech/project/lazypredict
+   :alt: Downloads
+
+.. image:: https://www.codefactor.io/repository/github/shankarpandala/lazypredict/badge
+   :target: https://www.codefactor.io/repository/github/shankarpandala/lazypredict
+   :alt: CodeFactor
+
+Quick Links
+----------
+* `Source Code <https://github.com/shankarpandala/lazypredict>`_
+* `Bug Reports <https://github.com/shankarpandala/lazypredict/issues>`_
+* `Documentation <https://lazypredict.readthedocs.io/>`_
+
+Contents
+--------
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Getting Started
 
-   readme
    installation
    usage
+   
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide
+
    modules
+   examples
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Development
+
    contributing
    authors
    history
 
-Indices and tables
-==================
+Features
+--------
+* Automatic model selection for classification and regression
+* Support for both numerical and categorical features
+* Easy integration with scikit-learn pipelines
+* Model performance comparison
+* Minimal code required
+* MLflow integration for experiment tracking
+
+Indices and Tables
+-----------------
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,8 @@
 sphinx>=4.0.0
-myst-parser
-sphinx-rtd-theme
+sphinx-rtd-theme>=1.0.0
+myst-parser>=0.18.0
+sphinx-autodoc-typehints>=1.19.0
+nbsphinx>=0.8.9
+sphinx-copybutton>=0.5.0
+sphinx-design>=0.2.0
+sphinxcontrib-napoleon>=0.7


### PR DESCRIPTION
- Create .readthedocs.yaml for Read the Docs configuration
- Add examples.rst with usage examples for classification and regression
- Update index.rst to include quick links and features
- Enhance requirements.txt with additional dependencies for documentation
- Modify conf.py to include new Sphinx extensions and settings