### PR TITLE
Fix: Handle list of strings in 'regressors' and 'classifiers' parameter (ValueError)

### DIFF
--- a/lazypredict/Supervised.py
+++ b/lazypredict/Supervised.py
@@ -382,7 +382,10 @@ class LazyClassifier:
         self.predictions = predictions
         self.models = {}
         self.random_state = random_state
-        self.classifiers = classifiers
+        if classifiers == "all":
+            self.classifiers = CLASSIFIERS
+        else:
+            self.classifiers = [(name,cls) for name, cls in CLASSIFIERS if name in classifiers]
         self.cv = cv  # K-fold cross-validation parameter
         self.timeout = timeout  # Timeout in seconds for each model
         self.categorical_encoder = categorical_encoder  # Encoder type for categorical features
@@ -975,7 +978,10 @@ class LazyRegressor:
         self.predictions = predictions
         self.models = {}
         self.random_state = random_state
-        self.regressors = regressors
+        if regressors == "all":
+            self.regressors = REGRESSORS
+        else:
+            self.regressors = [(name,cls) for name, cls in REGRESSORS if name in regressors]    
         self.cv = cv  # K-fold cross-validation parameter
         self.timeout = timeout  # Timeout in seconds for each model
         self.categorical_encoder = categorical_encoder  # Encoder type for categorical features


### PR DESCRIPTION
## Description
[Fixes #545 ]
This PR fixes a bug where passing a list of model names (as strings) to the `regressors` and `classifiers` parameters raised a `ValueError: too many values to unpack`.

According to the documentation, `regressors` and `classifiers` should accept a list of strings (`'all' or list of regressor names`),(`'all' or list of classifier names`). However, the implementation was missing the logic to map these strings to the actual model objects, causing the iteration to fail

## Changes Made
- Modified `Supervised.py` to check if `regressors` is a list of strings.
- Modified `Supervised.py` to check if `classifiers` is a list of strings.
- Added logic to filter the master `REGRESSORS` and `CLASSIFIERS` list based on the provided strings, ensuring the `fit` method receives the expected list of tuples `(name, model)`.