### PR TITLE
Add time series visualization and diagnostics modules

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # LazyPredict Roadmap — v0.3.x and Beyond
 
 **Last Updated:** 2026-03-10
-**Current Version:** 0.3.0a4
+**Current Version:** 0.3.0a5
 
 ---
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,3 +183,7 @@ napoleon_use_rtype = True
 napoleon_preprocess_types = False
 napoleon_type_aliases = None
 napoleon_attr_annotations = True
+
+# Suppress ambiguous cross-reference warnings for shared property names
+# (e.g. 'name' is defined on multiple forecaster classes).
+suppress_warnings = ["ref.python"]

--- a/lazypredict/TimeSeriesForecasting.py
+++ b/lazypredict/TimeSeriesForecasting.py
@@ -1493,89 +1493,99 @@ class LazyForecaster:
         -------
         matplotlib.figure.Figure
         """
-        from lazypredict.ts_visualization import (
-            plot_error_distribution,
-            plot_forecast,
-            plot_metrics_heatmap,
-            plot_model_comparison,
-            plot_residuals,
-        )
-
         y_train = y_train if y_train is not None else getattr(self, "_last_y_train", None)
         y_test = y_test if y_test is not None else getattr(self, "_last_y_test", None)
         predictions = getattr(self, "_last_predictions", {})
         scores = getattr(self, "_last_scores", None)
 
-        if plot_type == "forecast":
-            if y_train is None or y_test is None:
-                raise ValueError("y_train and y_test required. Call fit() first.")
-            if not predictions:
-                raise ValueError("No predictions available. Call fit() first.")
-            return plot_forecast(
-                y_train, y_test, predictions,
-                title=kwargs.get("title"),
-                figsize=kwargs.get("figsize", (12, 5)),
-                ax=kwargs.get("ax"),
-            )
-
-        elif plot_type == "comparison":
-            if scores is None or scores.empty:
-                raise ValueError("No scores available. Call fit() first.")
-            return plot_model_comparison(
-                scores,
-                metric=kwargs.get("metric", "RMSE"),
-                top_k=kwargs.get("top_k", 10),
-                figsize=kwargs.get("figsize", (10, 6)),
-                ax=kwargs.get("ax"),
-            )
-
-        elif plot_type == "residuals":
-            if y_test is None:
-                raise ValueError("y_test required. Call fit() first.")
-            model_name = kwargs.get("model_name")
-            if model_name:
-                if model_name not in predictions:
-                    raise ValueError(
-                        f"Model '{model_name}' not found in predictions. "
-                        f"Available: {list(predictions.keys())}"
-                    )
-                y_pred = predictions[model_name]
-            else:
-                # Use the best model (first in predictions)
-                model_name = next(iter(predictions))
-                y_pred = predictions[model_name]
-            return plot_residuals(
-                y_test, y_pred, model_name=model_name,
-                seasonal_period=kwargs.get("seasonal_period", getattr(self, "_last_seasonal_period", 1) or 1),
-                figsize=kwargs.get("figsize", (12, 10)),
-            )
-
-        elif plot_type == "errors":
-            if y_test is None:
-                raise ValueError("y_test required. Call fit() first.")
-            if not predictions:
-                raise ValueError("No predictions available. Call fit() first.")
-            return plot_error_distribution(
-                y_test, predictions,
-                figsize=kwargs.get("figsize", (10, 6)),
-                ax=kwargs.get("ax"),
-            )
-
-        elif plot_type == "heatmap":
-            if scores is None or scores.empty:
-                raise ValueError("No scores available. Call fit() first.")
-            return plot_metrics_heatmap(
-                scores,
-                metrics=kwargs.get("metrics"),
-                figsize=kwargs.get("figsize", (10, 8)),
-                ax=kwargs.get("ax"),
-            )
-
-        else:
+        handlers = {
+            "forecast": self._plot_forecast,
+            "comparison": self._plot_comparison,
+            "residuals": self._plot_residuals,
+            "errors": self._plot_errors,
+            "heatmap": self._plot_heatmap,
+        }
+        handler = handlers.get(plot_type)
+        if handler is None:
             raise ValueError(
                 f"Unknown plot_type: {plot_type!r}. "
-                "Use 'forecast', 'comparison', 'residuals', 'errors', or 'heatmap'."
+                f"Use {', '.join(repr(k) for k in handlers)}."
             )
+        return handler(y_train, y_test, predictions, scores, **kwargs)
+
+    def _plot_forecast(self, y_train, y_test, predictions, scores, **kwargs):
+        from lazypredict.ts_visualization import plot_forecast
+
+        if y_train is None or y_test is None:
+            raise ValueError("y_train and y_test required. Call fit() first.")
+        if not predictions:
+            raise ValueError("No predictions available. Call fit() first.")
+        return plot_forecast(
+            y_train, y_test, predictions,
+            title=kwargs.get("title"),
+            figsize=kwargs.get("figsize", (12, 5)),
+            ax=kwargs.get("ax"),
+        )
+
+    def _plot_comparison(self, y_train, y_test, predictions, scores, **kwargs):
+        from lazypredict.ts_visualization import plot_model_comparison
+
+        if scores is None or scores.empty:
+            raise ValueError("No scores available. Call fit() first.")
+        return plot_model_comparison(
+            scores,
+            metric=kwargs.get("metric", "RMSE"),
+            top_k=kwargs.get("top_k", 10),
+            figsize=kwargs.get("figsize", (10, 6)),
+            ax=kwargs.get("ax"),
+        )
+
+    def _plot_residuals(self, y_train, y_test, predictions, scores, **kwargs):
+        from lazypredict.ts_visualization import plot_residuals
+
+        if y_test is None:
+            raise ValueError("y_test required. Call fit() first.")
+        model_name = kwargs.get("model_name")
+        if model_name:
+            if model_name not in predictions:
+                raise ValueError(
+                    f"Model '{model_name}' not found in predictions. "
+                    f"Available: {list(predictions.keys())}"
+                )
+            y_pred = predictions[model_name]
+        else:
+            model_name = next(iter(predictions))
+            y_pred = predictions[model_name]
+        return plot_residuals(
+            y_test, y_pred, model_name=model_name,
+            seasonal_period=kwargs.get("seasonal_period", getattr(self, "_last_seasonal_period", 1) or 1),
+            figsize=kwargs.get("figsize", (12, 10)),
+        )
+
+    def _plot_errors(self, y_train, y_test, predictions, scores, **kwargs):
+        from lazypredict.ts_visualization import plot_error_distribution
+
+        if y_test is None:
+            raise ValueError("y_test required. Call fit() first.")
+        if not predictions:
+            raise ValueError("No predictions available. Call fit() first.")
+        return plot_error_distribution(
+            y_test, predictions,
+            figsize=kwargs.get("figsize", (10, 6)),
+            ax=kwargs.get("ax"),
+        )
+
+    def _plot_heatmap(self, y_train, y_test, predictions, scores, **kwargs):
+        from lazypredict.ts_visualization import plot_metrics_heatmap
+
+        if scores is None or scores.empty:
+            raise ValueError("No scores available. Call fit() first.")
+        return plot_metrics_heatmap(
+            scores,
+            metrics=kwargs.get("metrics"),
+            figsize=kwargs.get("figsize", (10, 8)),
+            ax=kwargs.get("ax"),
+        )
 
     def diagnose(
         self,

--- a/lazypredict/TimeSeriesForecasting.py
+++ b/lazypredict/TimeSeriesForecasting.py
@@ -1148,6 +1148,7 @@ class LazyForecaster:
         self.tune_seasonal = tune_seasonal
         self.horizon_strategy = horizon_strategy
         self.tuned_scores_: Optional[pd.DataFrame] = None
+        self.tuned_models_: Dict[str, ForecasterWrapper] = {}
 
         self.models: Dict[str, ForecasterWrapper] = {}
         self.errors: Dict[str, Exception] = {}
@@ -1239,8 +1240,8 @@ class LazyForecaster:
             results.append(metrics)
             if self.verbose > 0:
                 self._log_verbose(fname, metrics)
-            if self.predictions:
-                predictions_dict[fname] = y_pred
+            # Always store predictions internally for ensemble/plotting/diagnostics
+            predictions_dict[fname] = y_pred
 
             self._end_mlflow_run(mlflow_active_run)
             return metrics
@@ -1372,12 +1373,14 @@ class LazyForecaster:
 
         scores = self._build_scores_dataframe(results)
 
-        # Store for tuning / ensemble access
+        # Store for tuning / ensemble / plotting / diagnostics access
         self._last_y_train = y_train
+        self._last_y_test = y_test
         self._last_X_train = X_train
         self._last_seasonal_period = seasonal_period
         self._last_all_forecasters = all_forecasters
         self._last_predictions = predictions_dict
+        self._last_scores = scores
 
         # Auto-tune top-k if requested
         if self.tune and len(scores) > 0:
@@ -1387,7 +1390,7 @@ class LazyForecaster:
                 "Tuning top %d forecasters with Optuna (%d trials, metric=%s)...",
                 self.tune_top_k, self.tune_trials, self.tune_metric,
             )
-            self.tuned_scores_ = tune_top_k_forecasters(
+            self.tuned_scores_, self.tuned_models_ = tune_top_k_forecasters(
                 scores_df=scores,
                 models=self.models,
                 all_wrappers=all_forecasters,
@@ -1401,6 +1404,7 @@ class LazyForecaster:
                 timeout=self.tune_timeout,
                 random_state=self.random_state,
                 tune_seasonal=self.tune_seasonal,
+                refit=True,
             )
 
         if self.predictions:
@@ -1462,6 +1466,166 @@ class LazyForecaster:
             raise ValueError(
                 f"Unknown method: {method}. Use 'simple_average', 'weighted_average', or 'stacking'."
             )
+
+    def plot_results(
+        self,
+        y_train: Optional[np.ndarray] = None,
+        y_test: Optional[np.ndarray] = None,
+        plot_type: str = "forecast",
+        **kwargs,
+    ):
+        """Generate forecast visualizations.
+
+        Parameters
+        ----------
+        y_train : np.ndarray or None
+            Training series. Uses stored values from last ``fit()`` if None.
+        y_test : np.ndarray or None
+            Test series. Uses stored values from last ``fit()`` if None.
+        plot_type : str
+            One of ``'forecast'``, ``'comparison'``, ``'residuals'``,
+            ``'errors'``, ``'heatmap'``.
+        **kwargs
+            Passed to the underlying plot function (e.g. ``figsize``,
+            ``metric``, ``model_name``, ``top_k``).
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+        """
+        from lazypredict.ts_visualization import (
+            plot_error_distribution,
+            plot_forecast,
+            plot_metrics_heatmap,
+            plot_model_comparison,
+            plot_residuals,
+        )
+
+        y_train = y_train if y_train is not None else getattr(self, "_last_y_train", None)
+        y_test = y_test if y_test is not None else getattr(self, "_last_y_test", None)
+        predictions = getattr(self, "_last_predictions", {})
+        scores = getattr(self, "_last_scores", None)
+
+        if plot_type == "forecast":
+            if y_train is None or y_test is None:
+                raise ValueError("y_train and y_test required. Call fit() first.")
+            if not predictions:
+                raise ValueError("No predictions available. Call fit() first.")
+            return plot_forecast(
+                y_train, y_test, predictions,
+                title=kwargs.get("title"),
+                figsize=kwargs.get("figsize", (12, 5)),
+                ax=kwargs.get("ax"),
+            )
+
+        elif plot_type == "comparison":
+            if scores is None or scores.empty:
+                raise ValueError("No scores available. Call fit() first.")
+            return plot_model_comparison(
+                scores,
+                metric=kwargs.get("metric", "RMSE"),
+                top_k=kwargs.get("top_k", 10),
+                figsize=kwargs.get("figsize", (10, 6)),
+                ax=kwargs.get("ax"),
+            )
+
+        elif plot_type == "residuals":
+            if y_test is None:
+                raise ValueError("y_test required. Call fit() first.")
+            model_name = kwargs.get("model_name")
+            if model_name:
+                if model_name not in predictions:
+                    raise ValueError(
+                        f"Model '{model_name}' not found in predictions. "
+                        f"Available: {list(predictions.keys())}"
+                    )
+                y_pred = predictions[model_name]
+            else:
+                # Use the best model (first in predictions)
+                model_name = next(iter(predictions))
+                y_pred = predictions[model_name]
+            return plot_residuals(
+                y_test, y_pred, model_name=model_name,
+                seasonal_period=kwargs.get("seasonal_period", getattr(self, "_last_seasonal_period", 1) or 1),
+                figsize=kwargs.get("figsize", (12, 10)),
+            )
+
+        elif plot_type == "errors":
+            if y_test is None:
+                raise ValueError("y_test required. Call fit() first.")
+            if not predictions:
+                raise ValueError("No predictions available. Call fit() first.")
+            return plot_error_distribution(
+                y_test, predictions,
+                figsize=kwargs.get("figsize", (10, 6)),
+                ax=kwargs.get("ax"),
+            )
+
+        elif plot_type == "heatmap":
+            if scores is None or scores.empty:
+                raise ValueError("No scores available. Call fit() first.")
+            return plot_metrics_heatmap(
+                scores,
+                metrics=kwargs.get("metrics"),
+                figsize=kwargs.get("figsize", (10, 8)),
+                ax=kwargs.get("ax"),
+            )
+
+        else:
+            raise ValueError(
+                f"Unknown plot_type: {plot_type!r}. "
+                "Use 'forecast', 'comparison', 'residuals', 'errors', or 'heatmap'."
+            )
+
+    def diagnose(
+        self,
+        model_name: Optional[str] = None,
+        y_test: Optional[np.ndarray] = None,
+    ):
+        """Run residual diagnostics on fitted models.
+
+        Parameters
+        ----------
+        model_name : str or None
+            Specific model name. If None, runs diagnostics for all models
+            and returns a DataFrame.
+        y_test : np.ndarray or None
+            Test values. Uses stored values from last ``fit()`` if None.
+
+        Returns
+        -------
+        dict or pd.DataFrame
+            Single model returns a diagnostic dict; multiple models
+            returns a DataFrame with one row per model.
+        """
+        from lazypredict.ts_diagnostics import compare_diagnostics, residual_diagnostics
+
+        y_test = y_test if y_test is not None else getattr(self, "_last_y_test", None)
+        if y_test is None:
+            raise ValueError("y_test required. Call fit() first or pass y_test.")
+
+        predictions = getattr(self, "_last_predictions", {})
+        if not predictions:
+            raise ValueError("No predictions available. Call fit() first.")
+
+        y_train = getattr(self, "_last_y_train", None)
+        sp = getattr(self, "_last_seasonal_period", 1) or 1
+
+        if model_name is not None:
+            if model_name not in predictions:
+                raise ValueError(
+                    f"Model '{model_name}' not found. "
+                    f"Available: {list(predictions.keys())}"
+                )
+            return residual_diagnostics(
+                y_test, predictions[model_name],
+                y_train=y_train, seasonal_period=sp,
+            )
+
+        return compare_diagnostics(
+            y_test, predictions,
+            y_train=y_train, seasonal_period=sp,
+        )
 
     def provide_models(
         self,

--- a/lazypredict/TimeSeriesForecasting.py
+++ b/lazypredict/TimeSeriesForecasting.py
@@ -1308,7 +1308,34 @@ class LazyForecaster:
         predictions : pd.DataFrame
             Per-model predictions (empty if ``self.predictions`` is False).
         """
-        # Auto-convert PySpark/Dask inputs
+        y_train, y_test, X_train, X_test = self._convert_and_validate_inputs(
+            y_train, y_test, X_train, X_test
+        )
+        horizon = len(y_test)
+        seasonal_period = self._resolve_seasonal_period(y_train)
+
+        all_forecasters = self._resolve_forecasters(seasonal_period)
+
+        results: List[Dict[str, Any]] = []
+        predictions_dict: Dict[str, np.ndarray] = {}
+
+        self._run_all_models(
+            all_forecasters, y_train, y_test, X_train, X_test,
+            horizon, seasonal_period, results, predictions_dict,
+        )
+
+        scores = self._build_scores_dataframe(results)
+        self._store_fit_state(
+            y_train, y_test, X_train, seasonal_period,
+            all_forecasters, predictions_dict, scores,
+        )
+        self._auto_tune(scores, all_forecasters, y_train, X_train, seasonal_period)
+
+        if self.predictions:
+            return scores, pd.DataFrame.from_dict(predictions_dict)
+        return scores, pd.DataFrame()
+
+    def _convert_and_validate_inputs(self, y_train, y_test, X_train, X_test):
         from lazypredict.distributed import auto_convert_dataframe
 
         y_train = auto_convert_dataframe(y_train, "y_train")
@@ -1317,22 +1344,17 @@ class LazyForecaster:
             X_train = auto_convert_dataframe(X_train, "X_train")
         if X_test is not None:
             X_test = auto_convert_dataframe(X_test, "X_test")
+        return self._validate_fit_inputs(y_train, y_test, X_train, X_test)
 
-        y_train, y_test, X_train, X_test = self._validate_fit_inputs(
-            y_train, y_test, X_train, X_test
-        )
-        horizon = len(y_test)
-
-        # Auto-detect seasonal period
+    def _resolve_seasonal_period(self, y_train):
         seasonal_period = self.seasonal_period
         if seasonal_period is None:
             seasonal_period = detect_seasonal_period(y_train)
             if seasonal_period is not None and self.verbose > 0:
-                logger.info(
-                    "Auto-detected seasonal period: %d", seasonal_period
-                )
+                logger.info("Auto-detected seasonal period: %d", seasonal_period)
+        return seasonal_period
 
-        # Build forecaster list
+    def _resolve_forecasters(self, seasonal_period):
         all_forecasters = _build_forecaster_list(
             n_lags=self.n_lags,
             n_rolling=self.n_rolling,
@@ -1341,23 +1363,21 @@ class LazyForecaster:
             use_gpu=self.use_gpu,
             foundation_model_path=self.foundation_model_path,
         )
-
-        # Filter to user-specified subset
         if self.forecasters != "all":
             selected_names = set(self.forecasters)
             all_forecasters = [
                 (n, w) for n, w in all_forecasters if n in selected_names
             ]
-
         if self.max_models is not None:
             all_forecasters = all_forecasters[: self.max_models]
+        return all_forecasters
 
-        results: List[Dict[str, Any]] = []
-        predictions_dict: Dict[str, np.ndarray] = {}
-
+    def _run_all_models(
+        self, all_forecasters, y_train, y_test, X_train, X_test,
+        horizon, seasonal_period, results, predictions_dict,
+    ):
         progress_bar = notebook_tqdm if _use_notebook_tqdm else tqdm
         total = len(all_forecasters)
-
         with warnings.catch_warnings():
             if self.ignore_warnings:
                 warnings.simplefilter("ignore")
@@ -1371,9 +1391,10 @@ class LazyForecaster:
                 if self.progress_callback is not None:
                     self.progress_callback(fname, idx + 1, total, metrics)
 
-        scores = self._build_scores_dataframe(results)
-
-        # Store for tuning / ensemble / plotting / diagnostics access
+    def _store_fit_state(
+        self, y_train, y_test, X_train, seasonal_period,
+        all_forecasters, predictions_dict, scores,
+    ):
         self._last_y_train = y_train
         self._last_y_test = y_test
         self._last_X_train = X_train
@@ -1382,34 +1403,31 @@ class LazyForecaster:
         self._last_predictions = predictions_dict
         self._last_scores = scores
 
-        # Auto-tune top-k if requested
-        if self.tune and len(scores) > 0:
-            from lazypredict.ts_tuning import tune_top_k_forecasters
+    def _auto_tune(self, scores, all_forecasters, y_train, X_train, seasonal_period):
+        if not self.tune or len(scores) == 0:
+            return
+        from lazypredict.ts_tuning import tune_top_k_forecasters
 
-            logger.info(
-                "Tuning top %d forecasters with Optuna (%d trials, metric=%s)...",
-                self.tune_top_k, self.tune_trials, self.tune_metric,
-            )
-            self.tuned_scores_, self.tuned_models_ = tune_top_k_forecasters(
-                scores_df=scores,
-                models=self.models,
-                all_wrappers=all_forecasters,
-                y_train=y_train,
-                X_train=X_train,
-                seasonal_period=seasonal_period,
-                top_k=self.tune_top_k,
-                tune_metric=self.tune_metric,
-                cv=max(self.cv or 3, 3),
-                n_trials=self.tune_trials,
-                timeout=self.tune_timeout,
-                random_state=self.random_state,
-                tune_seasonal=self.tune_seasonal,
-                refit=True,
-            )
-
-        if self.predictions:
-            return scores, pd.DataFrame.from_dict(predictions_dict)
-        return scores, pd.DataFrame()
+        logger.info(
+            "Tuning top %d forecasters with Optuna (%d trials, metric=%s)...",
+            self.tune_top_k, self.tune_trials, self.tune_metric,
+        )
+        self.tuned_scores_, self.tuned_models_ = tune_top_k_forecasters(
+            scores_df=scores,
+            models=self.models,
+            all_wrappers=all_forecasters,
+            y_train=y_train,
+            X_train=X_train,
+            seasonal_period=seasonal_period,
+            top_k=self.tune_top_k,
+            tune_metric=self.tune_metric,
+            cv=max(self.cv or 3, 3),
+            n_trials=self.tune_trials,
+            timeout=self.tune_timeout,
+            random_state=self.random_state,
+            tune_seasonal=self.tune_seasonal,
+            refit=True,
+        )
 
     def ensemble(
         self,
@@ -1431,41 +1449,42 @@ class LazyForecaster:
         np.ndarray
             Ensembled predictions.
         """
-        from lazypredict.ensemble import (
-            ensemble_simple_average,
-            ensemble_stacking,
-            ensemble_weighted_average,
-        )
-
         if not self._last_predictions:
             raise ValueError(
                 "No predictions available. Call fit() with predictions=True first."
             )
 
         preds = self._last_predictions
-
-        if method == "simple_average":
-            return ensemble_simple_average(preds)
-        elif method == "weighted_average":
-            # Use model scores (RMSE by default) as weights
-            scores = {}
-            for name in preds:
-                if name in self.models:
-                    scores[name] = 1.0  # fallback
-            # Try to get actual scores from the last fit
-            if hasattr(self, "_last_scores_dict"):
-                for name, s in self._last_scores_dict.items():
-                    if name in preds:
-                        scores[name] = s
-            return ensemble_weighted_average(preds, scores)
-        elif method == "stacking":
-            if y_true is None:
-                raise ValueError("y_true is required for stacking ensemble.")
-            return ensemble_stacking(preds, y_true)
-        else:
+        handlers = {
+            "simple_average": self._ensemble_simple,
+            "weighted_average": self._ensemble_weighted,
+            "stacking": self._ensemble_stacking,
+        }
+        handler = handlers.get(method)
+        if handler is None:
             raise ValueError(
-                f"Unknown method: {method}. Use 'simple_average', 'weighted_average', or 'stacking'."
+                f"Unknown method: {method}. Use {', '.join(repr(k) for k in handlers)}."
             )
+        return handler(preds, y_true)
+
+    def _ensemble_simple(self, preds, y_true):
+        from lazypredict.ensemble import ensemble_simple_average
+        return ensemble_simple_average(preds)
+
+    def _ensemble_weighted(self, preds, y_true):
+        from lazypredict.ensemble import ensemble_weighted_average
+        scores = {name: 1.0 for name in preds if name in self.models}
+        if hasattr(self, "_last_scores_dict"):
+            for name, s in self._last_scores_dict.items():
+                if name in preds:
+                    scores[name] = s
+        return ensemble_weighted_average(preds, scores)
+
+    def _ensemble_stacking(self, preds, y_true):
+        from lazypredict.ensemble import ensemble_stacking
+        if y_true is None:
+            raise ValueError("y_true is required for stacking ensemble.")
+        return ensemble_stacking(preds, y_true)
 
     def plot_results(
         self,

--- a/lazypredict/__init__.py
+++ b/lazypredict/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Shankar Rao Pandala"""
 __email__ = "shankar.pandala@live.com"
-__version__ = '0.3.0a4'
+__version__ = '0.3.0a5'
 
 __all__ = [
     "LazyClassifier",

--- a/lazypredict/__init__.py
+++ b/lazypredict/__init__.py
@@ -23,6 +23,8 @@ __all__ = [
     "ts_search_spaces",
     "tuning",
     "ts_tuning",
+    "ts_visualization",
+    "ts_diagnostics",
     "ensemble",
     "horizon",
     "distributed",

--- a/lazypredict/distributed.py
+++ b/lazypredict/distributed.py
@@ -93,36 +93,30 @@ def register_dask_backend() -> bool:
 
     try:
         from dask.distributed import Client
-        import joblib
 
         # Register dask as a parallel backend
         try:
-            from joblib import parallel_config
+            from joblib import parallel_config  # noqa: F401
             # joblib >= 1.3 uses parallel_config
             _dask_backend_registered = True
         except ImportError:
             pass
 
-        # Try the older registration approach
+        # Check if a client is already running
         try:
-            from dask.distributed import Client
-            # Check if a client is already running
-            try:
-                client = Client.current()
-                logger.info(
-                    "Dask client found at %s — using Dask for parallel CV.",
-                    client.dashboard_link or "local",
-                )
-            except ValueError:
-                # No client running, create a local one
-                client = Client(processes=False, silence_logs=logging.WARNING)
-                logger.info(
-                    "Created local Dask client for parallel CV."
-                )
-            _dask_backend_registered = True
-            return True
-        except ImportError:
-            return False
+            client = Client.current()
+            logger.info(
+                "Dask client found at %s — using Dask for parallel CV.",
+                client.dashboard_link or "local",
+            )
+        except ValueError:
+            # No client running, create a local one
+            client = Client(processes=False, silence_logs=logging.WARNING)
+            logger.info(
+                "Created local Dask client for parallel CV."
+            )
+        _dask_backend_registered = True
+        return True
 
     except ImportError:
         logger.info(

--- a/lazypredict/ensemble.py
+++ b/lazypredict/ensemble.py
@@ -4,7 +4,7 @@ Supports simple averaging, inverse-error weighted averaging, and stacking.
 """
 
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import numpy as np
 

--- a/lazypredict/explainability.py
+++ b/lazypredict/explainability.py
@@ -5,7 +5,7 @@ and optional SHAP-based explanations for tree/linear models.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict
 
 import numpy as np
 import pandas as pd

--- a/lazypredict/horizon.py
+++ b/lazypredict/horizon.py
@@ -8,7 +8,6 @@ import logging
 from typing import Optional, Tuple
 
 import numpy as np
-from sklearn.base import clone
 from sklearn.multioutput import MultiOutputRegressor
 from sklearn.preprocessing import StandardScaler
 

--- a/lazypredict/search_spaces.py
+++ b/lazypredict/search_spaces.py
@@ -5,7 +5,7 @@ to pass to the model constructor.  Models not listed here are skipped during
 tuning (they have no meaningful hyperparameters or are too niche).
 """
 
-from typing import Any, Callable, Dict, Optional
+from typing import Callable, Dict, Optional
 
 
 def _ridge_space(trial) -> dict:

--- a/lazypredict/spark.py
+++ b/lazypredict/spark.py
@@ -8,7 +8,7 @@ Requires: pip install lazypredict[spark]
 
 import logging
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger("lazypredict")
 
@@ -20,16 +20,14 @@ try:
         GBTClassifier as SparkGBTC,
         LinearSVC as SparkLinearSVC,
         LogisticRegression as SparkLR,
-        MultilayerPerceptronClassifier as SparkMLPC,
         NaiveBayes as SparkNB,
         RandomForestClassifier as SparkRFC,
     )
     from pyspark.ml.evaluation import (
-        BinaryClassificationEvaluator,
         MulticlassClassificationEvaluator,
         RegressionEvaluator,
     )
-    from pyspark.ml.feature import StringIndexer, VectorAssembler
+    from pyspark.ml.feature import VectorAssembler
     from pyspark.ml.regression import (
         DecisionTreeRegressor as SparkDTR,
         GBTRegressor as SparkGBTR,

--- a/lazypredict/ts_diagnostics.py
+++ b/lazypredict/ts_diagnostics.py
@@ -6,7 +6,7 @@ and ACF computation. Falls back gracefully when statsmodels is unavailable.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -66,61 +66,64 @@ def residual_diagnostics(
     residuals = y_true - y_pred
     n = len(residuals)
 
+    if max_lags is None:
+        max_lags = min(n - 1, max(10, 2 * seasonal_period))
+    max_lags = max(1, min(max_lags, n - 1))
+
     result: Dict[str, Any] = {
         "residuals": residuals,
         "mean": float(np.mean(residuals)),
         "std": float(np.std(residuals, ddof=1)) if n > 1 else 0.0,
     }
+    result["acf_values"] = _compute_acf(residuals, max_lags)
+    result.update(_ljung_box(residuals, max_lags))
+    result.update(_jarque_bera(residuals))
+    return result
 
-    if max_lags is None:
-        max_lags = min(n - 1, max(10, 2 * seasonal_period))
-    max_lags = max(1, min(max_lags, n - 1))
 
-    # ACF computation
+def _compute_acf(residuals: np.ndarray, max_lags: int) -> np.ndarray:
+    """Compute ACF using statsmodels if available, else numpy fallback."""
+    n = len(residuals)
     if _STATSMODELS_AVAILABLE and n > 1:
         try:
-            acf_vals = sm_acf(residuals, nlags=max_lags, fft=True)
-            result["acf_values"] = acf_vals
+            return sm_acf(residuals, nlags=max_lags, fft=True)
         except Exception:
-            result["acf_values"] = _compute_acf_numpy(residuals, max_lags)
-    else:
-        result["acf_values"] = _compute_acf_numpy(residuals, max_lags)
+            pass
+    return _compute_acf_numpy(residuals, max_lags)
 
-    # Ljung-Box test
+
+def _ljung_box(residuals: np.ndarray, max_lags: int) -> Dict[str, Any]:
+    """Run Ljung-Box test, returning a dict of results."""
+    n = len(residuals)
     if _STATSMODELS_AVAILABLE and n > max_lags + 1:
         try:
             lb_result = acorr_ljungbox(residuals, lags=max_lags, return_df=True)
             lb_stat = float(lb_result.iloc[-1]["lb_stat"])
             lb_pvalue = float(lb_result.iloc[-1]["lb_pvalue"])
-            result["ljung_box_stat"] = lb_stat
-            result["ljung_box_pvalue"] = lb_pvalue
-            result["is_white_noise"] = lb_pvalue > 0.05
+            return {
+                "ljung_box_stat": lb_stat,
+                "ljung_box_pvalue": lb_pvalue,
+                "is_white_noise": lb_pvalue > 0.05,
+            }
         except Exception:
-            result["ljung_box_stat"] = None
-            result["ljung_box_pvalue"] = None
-            result["is_white_noise"] = None
-    else:
-        result["ljung_box_stat"] = None
-        result["ljung_box_pvalue"] = None
-        result["is_white_noise"] = None
+            pass
+    return {"ljung_box_stat": None, "ljung_box_pvalue": None, "is_white_noise": None}
 
-    # Jarque-Bera test
+
+def _jarque_bera(residuals: np.ndarray) -> Dict[str, Any]:
+    """Run Jarque-Bera test, returning a dict of results."""
+    n = len(residuals)
     if _STATSMODELS_AVAILABLE and n >= 8:
         try:
             jb_stat, jb_pvalue, skew, kurtosis = jarque_bera(residuals)
-            result["jarque_bera_stat"] = float(jb_stat)
-            result["jarque_bera_pvalue"] = float(jb_pvalue)
-            result["is_normal"] = float(jb_pvalue) > 0.05
+            return {
+                "jarque_bera_stat": float(jb_stat),
+                "jarque_bera_pvalue": float(jb_pvalue),
+                "is_normal": float(jb_pvalue) > 0.05,
+            }
         except Exception:
-            result["jarque_bera_stat"] = None
-            result["jarque_bera_pvalue"] = None
-            result["is_normal"] = None
-    else:
-        result["jarque_bera_stat"] = None
-        result["jarque_bera_pvalue"] = None
-        result["is_normal"] = None
-
-    return result
+            pass
+    return {"jarque_bera_stat": None, "jarque_bera_pvalue": None, "is_normal": None}
 
 
 def compare_diagnostics(

--- a/lazypredict/ts_diagnostics.py
+++ b/lazypredict/ts_diagnostics.py
@@ -1,0 +1,188 @@
+"""Residual diagnostics for time series forecasting models.
+
+Provides statistical tests and analysis to validate forecast quality:
+Ljung-Box test for autocorrelation, Jarque-Bera test for normality,
+and ACF computation. Falls back gracefully when statsmodels is unavailable.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger("lazypredict")
+
+# Optional statsmodels for statistical tests
+try:
+    from statsmodels.stats.diagnostic import acorr_ljungbox
+    from statsmodels.stats.stattools import jarque_bera
+    from statsmodels.tsa.stattools import acf as sm_acf
+
+    _STATSMODELS_AVAILABLE = True
+except ImportError:
+    _STATSMODELS_AVAILABLE = False
+
+
+def residual_diagnostics(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    y_train: Optional[np.ndarray] = None,
+    seasonal_period: int = 1,
+    max_lags: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Compute comprehensive residual diagnostics.
+
+    Parameters
+    ----------
+    y_true : array-like
+        Actual values.
+    y_pred : array-like
+        Predicted values.
+    y_train : array-like or None
+        Training data (unused currently, reserved for future MASE-based tests).
+    seasonal_period : int
+        Seasonal period for selecting ACF lag count.
+    max_lags : int or None
+        Maximum number of ACF lags. Defaults to ``min(len(residuals)-1, max(10, 2*seasonal_period))``.
+
+    Returns
+    -------
+    dict
+        Keys:
+        - ``residuals``: np.ndarray — raw residuals (y_true - y_pred)
+        - ``mean``: float — mean of residuals (should be near 0)
+        - ``std``: float — standard deviation of residuals
+        - ``ljung_box_stat``: float or None — Ljung-Box Q statistic
+        - ``ljung_box_pvalue``: float or None — p-value (>0.05 = white noise)
+        - ``jarque_bera_stat``: float or None — Jarque-Bera statistic
+        - ``jarque_bera_pvalue``: float or None — p-value (>0.05 = normal)
+        - ``acf_values``: np.ndarray — autocorrelation values
+        - ``is_white_noise``: bool — True if Ljung-Box p > 0.05
+        - ``is_normal``: bool — True if Jarque-Bera p > 0.05
+    """
+    y_true = np.asarray(y_true, dtype=float)
+    y_pred = np.asarray(y_pred, dtype=float)
+    residuals = y_true - y_pred
+    n = len(residuals)
+
+    result: Dict[str, Any] = {
+        "residuals": residuals,
+        "mean": float(np.mean(residuals)),
+        "std": float(np.std(residuals, ddof=1)) if n > 1 else 0.0,
+    }
+
+    if max_lags is None:
+        max_lags = min(n - 1, max(10, 2 * seasonal_period))
+    max_lags = max(1, min(max_lags, n - 1))
+
+    # ACF computation
+    if _STATSMODELS_AVAILABLE and n > 1:
+        try:
+            acf_vals = sm_acf(residuals, nlags=max_lags, fft=True)
+            result["acf_values"] = acf_vals
+        except Exception:
+            result["acf_values"] = _compute_acf_numpy(residuals, max_lags)
+    else:
+        result["acf_values"] = _compute_acf_numpy(residuals, max_lags)
+
+    # Ljung-Box test
+    if _STATSMODELS_AVAILABLE and n > max_lags + 1:
+        try:
+            lb_result = acorr_ljungbox(residuals, lags=max_lags, return_df=True)
+            lb_stat = float(lb_result.iloc[-1]["lb_stat"])
+            lb_pvalue = float(lb_result.iloc[-1]["lb_pvalue"])
+            result["ljung_box_stat"] = lb_stat
+            result["ljung_box_pvalue"] = lb_pvalue
+            result["is_white_noise"] = lb_pvalue > 0.05
+        except Exception:
+            result["ljung_box_stat"] = None
+            result["ljung_box_pvalue"] = None
+            result["is_white_noise"] = None
+    else:
+        result["ljung_box_stat"] = None
+        result["ljung_box_pvalue"] = None
+        result["is_white_noise"] = None
+
+    # Jarque-Bera test
+    if _STATSMODELS_AVAILABLE and n >= 8:
+        try:
+            jb_stat, jb_pvalue, skew, kurtosis = jarque_bera(residuals)
+            result["jarque_bera_stat"] = float(jb_stat)
+            result["jarque_bera_pvalue"] = float(jb_pvalue)
+            result["is_normal"] = float(jb_pvalue) > 0.05
+        except Exception:
+            result["jarque_bera_stat"] = None
+            result["jarque_bera_pvalue"] = None
+            result["is_normal"] = None
+    else:
+        result["jarque_bera_stat"] = None
+        result["jarque_bera_pvalue"] = None
+        result["is_normal"] = None
+
+    return result
+
+
+def compare_diagnostics(
+    y_true: np.ndarray,
+    predictions: Dict[str, np.ndarray],
+    y_train: Optional[np.ndarray] = None,
+    seasonal_period: int = 1,
+) -> pd.DataFrame:
+    """Run residual diagnostics across multiple models.
+
+    Parameters
+    ----------
+    y_true : array-like
+        Actual values.
+    predictions : dict
+        ``{model_name: y_pred}`` mapping.
+    y_train : array-like or None
+        Training data.
+    seasonal_period : int
+        Seasonal period.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per model with diagnostic statistics.
+    """
+    if not predictions:
+        raise ValueError("No predictions provided.")
+
+    rows = []
+    for name, y_pred in predictions.items():
+        diag = residual_diagnostics(
+            y_true, y_pred, y_train=y_train, seasonal_period=seasonal_period
+        )
+        rows.append({
+            "Model": name,
+            "Residual Mean": diag["mean"],
+            "Residual Std": diag["std"],
+            "Ljung-Box Stat": diag["ljung_box_stat"],
+            "Ljung-Box p-value": diag["ljung_box_pvalue"],
+            "White Noise": diag["is_white_noise"],
+            "Jarque-Bera Stat": diag["jarque_bera_stat"],
+            "Jarque-Bera p-value": diag["jarque_bera_pvalue"],
+            "Normal": diag["is_normal"],
+        })
+
+    return pd.DataFrame(rows).set_index("Model")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _compute_acf_numpy(x: np.ndarray, max_lag: int) -> np.ndarray:
+    """Compute autocorrelation using numpy (fallback when statsmodels unavailable)."""
+    x = x - np.mean(x)
+    n = len(x)
+    var = np.sum(x ** 2) / n
+    if var == 0:
+        return np.zeros(max_lag + 1)
+    acf = np.array([
+        np.sum(x[: n - k] * x[k:]) / (n * var)
+        for k in range(max_lag + 1)
+    ])
+    return acf

--- a/lazypredict/ts_diagnostics.py
+++ b/lazypredict/ts_diagnostics.py
@@ -84,46 +84,49 @@ def residual_diagnostics(
 def _compute_acf(residuals: np.ndarray, max_lags: int) -> np.ndarray:
     """Compute ACF using statsmodels if available, else numpy fallback."""
     n = len(residuals)
-    if _STATSMODELS_AVAILABLE and n > 1:
-        try:
-            return sm_acf(residuals, nlags=max_lags, fft=True)
-        except Exception:
-            pass
-    return _compute_acf_numpy(residuals, max_lags)
+    if not (_STATSMODELS_AVAILABLE and n > 1):
+        return _compute_acf_numpy(residuals, max_lags)
+    try:
+        return sm_acf(residuals, nlags=max_lags, fft=True)
+    except Exception:
+        # Edge cases may cause statsmodels to fail; fall back to numpy
+        return _compute_acf_numpy(residuals, max_lags)
 
 
 def _ljung_box(residuals: np.ndarray, max_lags: int) -> Dict[str, Any]:
     """Run Ljung-Box test, returning a dict of results."""
     n = len(residuals)
-    if _STATSMODELS_AVAILABLE and n > max_lags + 1:
-        try:
-            lb_result = acorr_ljungbox(residuals, lags=max_lags, return_df=True)
-            lb_stat = float(lb_result.iloc[-1]["lb_stat"])
-            lb_pvalue = float(lb_result.iloc[-1]["lb_pvalue"])
-            return {
-                "ljung_box_stat": lb_stat,
-                "ljung_box_pvalue": lb_pvalue,
-                "is_white_noise": lb_pvalue > 0.05,
-            }
-        except Exception:
-            pass
-    return {"ljung_box_stat": None, "ljung_box_pvalue": None, "is_white_noise": None}
+    if not (_STATSMODELS_AVAILABLE and n > max_lags + 1):
+        return {"ljung_box_stat": None, "ljung_box_pvalue": None, "is_white_noise": None}
+    try:
+        lb_result = acorr_ljungbox(residuals, lags=max_lags, return_df=True)
+        lb_stat = float(lb_result.iloc[-1]["lb_stat"])
+        lb_pvalue = float(lb_result.iloc[-1]["lb_pvalue"])
+        return {
+            "ljung_box_stat": lb_stat,
+            "ljung_box_pvalue": lb_pvalue,
+            "is_white_noise": lb_pvalue > 0.05,
+        }
+    except Exception:
+        # Edge cases may cause statsmodels to fail
+        return {"ljung_box_stat": None, "ljung_box_pvalue": None, "is_white_noise": None}
 
 
 def _jarque_bera(residuals: np.ndarray) -> Dict[str, Any]:
     """Run Jarque-Bera test, returning a dict of results."""
     n = len(residuals)
-    if _STATSMODELS_AVAILABLE and n >= 8:
-        try:
-            jb_stat, jb_pvalue, skew, kurtosis = jarque_bera(residuals)
-            return {
-                "jarque_bera_stat": float(jb_stat),
-                "jarque_bera_pvalue": float(jb_pvalue),
-                "is_normal": float(jb_pvalue) > 0.05,
-            }
-        except Exception:
-            pass
-    return {"jarque_bera_stat": None, "jarque_bera_pvalue": None, "is_normal": None}
+    if not (_STATSMODELS_AVAILABLE and n >= 8):
+        return {"jarque_bera_stat": None, "jarque_bera_pvalue": None, "is_normal": None}
+    try:
+        jb_stat, jb_pvalue, skew, kurtosis = jarque_bera(residuals)
+        return {
+            "jarque_bera_stat": float(jb_stat),
+            "jarque_bera_pvalue": float(jb_pvalue),
+            "is_normal": float(jb_pvalue) > 0.05,
+        }
+    except Exception:
+        # Edge cases may cause statsmodels to fail
+        return {"jarque_bera_stat": None, "jarque_bera_pvalue": None, "is_normal": None}
 
 
 def compare_diagnostics(

--- a/lazypredict/ts_tuning.py
+++ b/lazypredict/ts_tuning.py
@@ -7,8 +7,7 @@ search, and temporal cross-validation.
 
 import copy
 import logging
-import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -148,32 +147,39 @@ def _apply_params_to_wrapper(wrapper, model_name, params, n_lags, n_rolling_1, n
     """Apply tuned parameters to a forecaster wrapper instance."""
     from lazypredict.TimeSeriesForecasting import MLForecaster, _TorchRNNForecaster
 
-    # ML/DL models: update feature-engineering params
-    if isinstance(wrapper, (MLForecaster, _TorchRNNForecaster)):
-        if n_lags is not None:
-            wrapper.n_lags = n_lags
-        if n_rolling_1 is not None and n_rolling_2 is not None:
-            wrapper.n_rolling = (n_rolling_1, n_rolling_2)
+    _apply_feature_engineering_params(wrapper, n_lags, n_rolling_1, n_rolling_2)
+    _apply_stat_model_params(wrapper, model_name, params, sp)
 
-    # Statistical model params applied at fit time via wrapper attributes
-    if model_name == "SARIMAX" and "order" in params:
-        wrapper.order = params["order"]
-    if model_name in ("HoltWinters_Add", "HoltWinters_Mul") and sp is not None:
-        wrapper.seasonal_periods = sp
-
-    # DL-specific params
     if isinstance(wrapper, _TorchRNNForecaster):
         for key in ("hidden_size", "learning_rate", "batch_size", "n_epochs"):
             if key in params:
                 setattr(wrapper, key, params[key])
 
-    # ML model estimator params
     if isinstance(wrapper, MLForecaster):
-        # Store extra model params to be passed at fit time
         model_params = {k: v for k, v in params.items()
                         if k not in ("order", "seasonal_period")}
         if model_params:
             wrapper._tune_params = model_params
+
+
+def _apply_feature_engineering_params(wrapper, n_lags, n_rolling_1, n_rolling_2):
+    """Set lag/rolling params on ML/DL wrappers."""
+    from lazypredict.TimeSeriesForecasting import MLForecaster, _TorchRNNForecaster
+
+    if not isinstance(wrapper, (MLForecaster, _TorchRNNForecaster)):
+        return
+    if n_lags is not None:
+        wrapper.n_lags = n_lags
+    if n_rolling_1 is not None and n_rolling_2 is not None:
+        wrapper.n_rolling = (n_rolling_1, n_rolling_2)
+
+
+def _apply_stat_model_params(wrapper, model_name, params, sp):
+    """Set statistical model-specific parameters."""
+    if model_name == "SARIMAX" and "order" in params:
+        wrapper.order = params["order"]
+    if model_name in ("HoltWinters_Add", "HoltWinters_Mul") and sp is not None:
+        wrapper.seasonal_periods = sp
 
 
 def tune_top_k_forecasters(

--- a/lazypredict/ts_tuning.py
+++ b/lazypredict/ts_tuning.py
@@ -189,13 +189,49 @@ def tune_top_k_forecasters(
     timeout: Optional[float] = None,
     random_state: int = 42,
     tune_seasonal: bool = False,
-) -> "pd.DataFrame":
+    refit: bool = True,
+) -> Tuple["pd.DataFrame", Dict[str, Any]]:
     """Tune the top-k forecasters from initial ranking.
+
+    Parameters
+    ----------
+    scores_df : pd.DataFrame
+        Ranked model scores from initial benchmarking.
+    models : dict
+        Fitted model wrappers.
+    all_wrappers : list of (name, wrapper) tuples
+        All available forecaster wrappers.
+    y_train : np.ndarray
+        Training time series.
+    X_train : np.ndarray or None
+        Exogenous features.
+    seasonal_period : int or None
+        Seasonal period.
+    top_k : int
+        Number of top models to tune.
+    tune_metric : str
+        Metric to optimize.
+    cv : int
+        Number of CV folds.
+    n_trials : int
+        Optuna trials per model.
+    timeout : float or None
+        Seconds limit per model tuning.
+    random_state : int
+        Random seed.
+    tune_seasonal : bool
+        Search over seasonal_period values.
+    refit : bool
+        When True, refit each tuned model on full ``y_train`` with
+        best parameters and return the fitted wrappers.
 
     Returns
     -------
-    pd.DataFrame
+    tune_results : pd.DataFrame
         Tuning results: Model, Best Score, Best Params.
+    tuned_models : dict
+        ``{model_name: fitted_wrapper}`` when ``refit=True``,
+        empty dict otherwise.
     """
     import pandas as pd
 
@@ -203,6 +239,8 @@ def tune_top_k_forecasters(
     name_to_wrapper = {name: w for name, w in all_wrappers}
 
     results = []
+    tuned_models: Dict[str, Any] = {}
+
     for model_name in top_model_names:
         wrapper = name_to_wrapper.get(model_name)
         if wrapper is None:
@@ -231,4 +269,24 @@ def tune_top_k_forecasters(
             "Best Params": str(best_params),
         })
 
-    return pd.DataFrame(results).set_index("Model")
+        # Refit with best params on full training data
+        if refit and best_params:
+            try:
+                w = copy.deepcopy(wrapper)
+                n_lags = best_params.pop("n_lags", None)
+                n_rolling_1 = best_params.pop("n_rolling_1", None)
+                n_rolling_2 = best_params.pop("n_rolling_2", None)
+                sp = best_params.pop("seasonal_period", seasonal_period)
+                _apply_params_to_wrapper(
+                    w, model_name, best_params,
+                    n_lags, n_rolling_1, n_rolling_2, sp,
+                )
+                w.fit(y_train, X_train)
+                tuned_models[model_name] = w
+                logger.info("Refit %s with best params.", model_name)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to refit %s with best params: %s", model_name, exc
+                )
+
+    return pd.DataFrame(results).set_index("Model"), tuned_models

--- a/lazypredict/ts_tuning.py
+++ b/lazypredict/ts_tuning.py
@@ -11,6 +11,7 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
+import pandas as pd
 from sklearn.model_selection import TimeSeriesSplit
 
 from lazypredict.metrics import compute_forecast_metrics

--- a/lazypredict/ts_visualization.py
+++ b/lazypredict/ts_visualization.py
@@ -1,0 +1,427 @@
+"""Time series forecasting visualization functions.
+
+Provides plotting utilities for forecast analysis, model comparison,
+residual diagnostics, and error distribution. All functions require
+matplotlib (optional dependency).
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger("lazypredict")
+
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    _MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    _MATPLOTLIB_AVAILABLE = False
+
+
+def _check_matplotlib():
+    """Raise ImportError if matplotlib is not installed."""
+    if not _MATPLOTLIB_AVAILABLE:
+        raise ImportError(
+            "matplotlib is required for plotting. "
+            "Install with: pip install lazypredict[viz]"
+        )
+
+
+def plot_forecast(
+    y_train: np.ndarray,
+    y_test: np.ndarray,
+    predictions: Union[np.ndarray, Dict[str, np.ndarray]],
+    title: Optional[str] = None,
+    figsize: Tuple[int, int] = (12, 5),
+    ax: Optional[Any] = None,
+) -> Any:
+    """Plot actual series with forecast overlay.
+
+    Parameters
+    ----------
+    y_train : np.ndarray
+        Training series shown as historical context.
+    y_test : np.ndarray
+        Actual test values.
+    predictions : np.ndarray or dict
+        Single prediction array or ``{model_name: y_pred}`` dict.
+    title : str or None
+        Plot title.
+    figsize : tuple
+        Figure size.
+    ax : matplotlib Axes or None
+        Axes to plot on. Created if None.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    _check_matplotlib()
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.get_figure()
+
+    n_train = len(y_train)
+    n_test = len(y_test)
+    train_idx = np.arange(n_train)
+    test_idx = np.arange(n_train, n_train + n_test)
+
+    ax.plot(train_idx, y_train, color="steelblue", label="Train", alpha=0.7)
+    ax.plot(test_idx, y_test, color="black", label="Actual", linewidth=2)
+
+    if isinstance(predictions, dict):
+        colors = plt.cm.Set2(np.linspace(0, 1, max(len(predictions), 1)))
+        for i, (name, y_pred) in enumerate(predictions.items()):
+            ax.plot(
+                test_idx[: len(y_pred)],
+                y_pred,
+                label=name,
+                color=colors[i % len(colors)],
+                linestyle="--",
+                linewidth=1.5,
+            )
+    else:
+        ax.plot(
+            test_idx[: len(predictions)],
+            predictions,
+            label="Forecast",
+            color="red",
+            linestyle="--",
+            linewidth=1.5,
+        )
+
+    ax.axvline(x=n_train, color="gray", linestyle=":", alpha=0.5)
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Value")
+    ax.set_title(title or "Forecast vs Actual")
+    ax.legend(loc="best", fontsize=8)
+    fig.tight_layout()
+    return fig
+
+
+def plot_model_comparison(
+    scores_df: pd.DataFrame,
+    metric: str = "RMSE",
+    top_k: int = 10,
+    figsize: Tuple[int, int] = (10, 6),
+    ax: Optional[Any] = None,
+) -> Any:
+    """Horizontal bar chart comparing models by a metric.
+
+    Parameters
+    ----------
+    scores_df : pd.DataFrame
+        Scores table from ``LazyForecaster.fit()`` (index = model names).
+    metric : str
+        Metric column to plot.
+    top_k : int
+        Show only the top k models.
+    figsize : tuple
+        Figure size.
+    ax : matplotlib Axes or None
+        Axes to plot on.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    _check_matplotlib()
+
+    if metric not in scores_df.columns:
+        raise ValueError(
+            f"Metric '{metric}' not found. Available: {list(scores_df.columns)}"
+        )
+
+    data = scores_df[metric].dropna().head(top_k)
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.get_figure()
+
+    colors = plt.cm.RdYlGn_r(np.linspace(0.2, 0.8, len(data)))
+    ax.barh(range(len(data)), data.values, color=colors)
+    ax.set_yticks(range(len(data)))
+    ax.set_yticklabels(data.index, fontsize=9)
+    ax.set_xlabel(metric)
+    ax.set_title(f"Model Comparison by {metric}")
+    ax.invert_yaxis()
+    fig.tight_layout()
+    return fig
+
+
+def plot_residuals(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    model_name: Optional[str] = None,
+    seasonal_period: int = 1,
+    figsize: Tuple[int, int] = (12, 10),
+) -> Any:
+    """Four-panel residual diagnostic plot.
+
+    Panels:
+        1. Residuals over time (scatter with zero line)
+        2. Histogram of residuals
+        3. QQ plot against normal distribution
+        4. ACF of residuals with confidence bands
+
+    Parameters
+    ----------
+    y_true : np.ndarray
+        Actual values.
+    y_pred : np.ndarray
+        Predicted values.
+    model_name : str or None
+        Model name for the title.
+    seasonal_period : int
+        Seasonal period for ACF display.
+    figsize : tuple
+        Figure size.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    _check_matplotlib()
+
+    y_true = np.asarray(y_true, dtype=float)
+    y_pred = np.asarray(y_pred, dtype=float)
+    residuals = y_true - y_pred
+
+    fig, axes = plt.subplots(2, 2, figsize=figsize)
+    title = f"Residual Diagnostics — {model_name}" if model_name else "Residual Diagnostics"
+    fig.suptitle(title, fontsize=14)
+
+    # Panel 1: Residuals over time
+    ax1 = axes[0, 0]
+    ax1.scatter(range(len(residuals)), residuals, s=20, alpha=0.7, color="steelblue")
+    ax1.axhline(y=0, color="red", linestyle="--", linewidth=1)
+    ax1.set_xlabel("Index")
+    ax1.set_ylabel("Residual")
+    ax1.set_title("Residuals Over Time")
+
+    # Panel 2: Histogram
+    ax2 = axes[0, 1]
+    ax2.hist(residuals, bins="auto", density=True, alpha=0.7, color="steelblue", edgecolor="white")
+    # Overlay normal curve
+    mu, sigma = np.mean(residuals), np.std(residuals)
+    if sigma > 0:
+        x_norm = np.linspace(mu - 4 * sigma, mu + 4 * sigma, 100)
+        y_norm = (1 / (sigma * np.sqrt(2 * np.pi))) * np.exp(-0.5 * ((x_norm - mu) / sigma) ** 2)
+        ax2.plot(x_norm, y_norm, color="red", linewidth=1.5, label="Normal")
+        ax2.legend(fontsize=8)
+    ax2.set_xlabel("Residual")
+    ax2.set_ylabel("Density")
+    ax2.set_title("Residual Distribution")
+
+    # Panel 3: QQ Plot
+    ax3 = axes[1, 0]
+    sorted_residuals = np.sort(residuals)
+    n = len(sorted_residuals)
+    theoretical_quantiles = np.array([
+        _norm_ppf((i - 0.5) / n) for i in range(1, n + 1)
+    ])
+    ax3.scatter(theoretical_quantiles, sorted_residuals, s=20, alpha=0.7, color="steelblue")
+    # Reference line
+    q1_idx, q3_idx = max(0, n // 4 - 1), min(n - 1, 3 * n // 4 - 1)
+    if q3_idx > q1_idx:
+        tq1, tq3 = theoretical_quantiles[q1_idx], theoretical_quantiles[q3_idx]
+        sq1, sq3 = sorted_residuals[q1_idx], sorted_residuals[q3_idx]
+        slope = (sq3 - sq1) / (tq3 - tq1) if tq3 != tq1 else 1
+        intercept = sq1 - slope * tq1
+        line_x = np.array([theoretical_quantiles[0], theoretical_quantiles[-1]])
+        ax3.plot(line_x, slope * line_x + intercept, color="red", linestyle="--", linewidth=1)
+    ax3.set_xlabel("Theoretical Quantiles")
+    ax3.set_ylabel("Sample Quantiles")
+    ax3.set_title("Q-Q Plot")
+
+    # Panel 4: ACF
+    ax4 = axes[1, 1]
+    max_lag = min(len(residuals) - 1, max(20, 2 * seasonal_period))
+    acf_values = _compute_acf(residuals, max_lag)
+    conf_bound = 1.96 / np.sqrt(len(residuals))
+    ax4.bar(range(len(acf_values)), acf_values, width=0.3, color="steelblue")
+    ax4.axhline(y=conf_bound, color="red", linestyle="--", linewidth=0.8, alpha=0.7)
+    ax4.axhline(y=-conf_bound, color="red", linestyle="--", linewidth=0.8, alpha=0.7)
+    ax4.axhline(y=0, color="black", linewidth=0.5)
+    ax4.set_xlabel("Lag")
+    ax4.set_ylabel("ACF")
+    ax4.set_title("Autocorrelation of Residuals")
+
+    fig.tight_layout(rect=[0, 0, 1, 0.96])
+    return fig
+
+
+def plot_error_distribution(
+    y_true: np.ndarray,
+    predictions: Dict[str, np.ndarray],
+    figsize: Tuple[int, int] = (10, 6),
+    ax: Optional[Any] = None,
+) -> Any:
+    """Box plot of absolute errors across models.
+
+    Parameters
+    ----------
+    y_true : np.ndarray
+        Actual values.
+    predictions : dict
+        ``{model_name: y_pred}`` dict.
+    figsize : tuple
+        Figure size.
+    ax : matplotlib Axes or None
+        Axes to plot on.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    _check_matplotlib()
+
+    y_true = np.asarray(y_true, dtype=float)
+    if not predictions:
+        raise ValueError("No predictions provided.")
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.get_figure()
+
+    error_data = []
+    labels = []
+    for name, y_pred in predictions.items():
+        y_pred = np.asarray(y_pred, dtype=float)
+        abs_errors = np.abs(y_true[: len(y_pred)] - y_pred)
+        error_data.append(abs_errors)
+        labels.append(name)
+
+    bp = ax.boxplot(error_data, patch_artist=True, tick_labels=labels)
+    colors = plt.cm.Set2(np.linspace(0, 1, len(error_data)))
+    for patch, color in zip(bp["boxes"], colors):
+        patch.set_facecolor(color)
+
+    ax.set_ylabel("Absolute Error")
+    ax.set_title("Error Distribution by Model")
+    if len(labels) > 5:
+        ax.tick_params(axis="x", rotation=45)
+    fig.tight_layout()
+    return fig
+
+
+def plot_metrics_heatmap(
+    scores_df: pd.DataFrame,
+    metrics: Optional[List[str]] = None,
+    figsize: Tuple[int, int] = (10, 8),
+    ax: Optional[Any] = None,
+) -> Any:
+    """Heatmap of normalized metrics across models.
+
+    Metrics are min-max normalized to [0, 1] for visual comparison.
+
+    Parameters
+    ----------
+    scores_df : pd.DataFrame
+        Scores table from ``LazyForecaster.fit()``.
+    metrics : list of str or None
+        Metric columns to include. Defaults to MAE, RMSE, MAPE, SMAPE, MASE.
+    figsize : tuple
+        Figure size.
+    ax : matplotlib Axes or None
+        Axes to plot on.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    _check_matplotlib()
+
+    if metrics is None:
+        metrics = [m for m in ["MAE", "RMSE", "MAPE", "SMAPE", "MASE"] if m in scores_df.columns]
+    if not metrics:
+        raise ValueError("No valid metrics found in scores DataFrame.")
+
+    data = scores_df[metrics].dropna()
+    if data.empty:
+        raise ValueError("No data to plot after dropping NaN values.")
+
+    # Min-max normalize each column
+    normalized = data.copy()
+    for col in metrics:
+        col_min, col_max = data[col].min(), data[col].max()
+        if col_max > col_min:
+            normalized[col] = (data[col] - col_min) / (col_max - col_min)
+        else:
+            normalized[col] = 0.0
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.get_figure()
+
+    im = ax.imshow(normalized.values, cmap="RdYlGn_r", aspect="auto")
+    ax.set_xticks(range(len(metrics)))
+    ax.set_xticklabels(metrics, fontsize=10)
+    ax.set_yticks(range(len(normalized)))
+    ax.set_yticklabels(normalized.index, fontsize=9)
+
+    # Annotate with original values
+    for i in range(len(normalized)):
+        for j in range(len(metrics)):
+            val = data.iloc[i, j]
+            text_color = "white" if normalized.iloc[i, j] > 0.6 else "black"
+            ax.text(j, i, f"{val:.2f}", ha="center", va="center",
+                    fontsize=8, color=text_color)
+
+    ax.set_title("Metrics Heatmap (normalized)")
+    fig.colorbar(im, ax=ax, shrink=0.8, label="Normalized (lower=better)")
+    fig.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _compute_acf(x: np.ndarray, max_lag: int) -> np.ndarray:
+    """Compute autocorrelation function up to max_lag."""
+    x = x - np.mean(x)
+    n = len(x)
+    var = np.sum(x ** 2) / n
+    if var == 0:
+        return np.zeros(max_lag + 1)
+    acf = np.array([
+        np.sum(x[: n - k] * x[k:]) / (n * var)
+        for k in range(max_lag + 1)
+    ])
+    return acf
+
+
+def _norm_ppf(p: float) -> float:
+    """Approximate normal quantile function (inverse CDF).
+
+    Uses the rational approximation by Abramowitz and Stegun.
+    """
+    if p <= 0:
+        return -6.0
+    if p >= 1:
+        return 6.0
+    if p == 0.5:
+        return 0.0
+
+    if p < 0.5:
+        t = np.sqrt(-2.0 * np.log(p))
+    else:
+        t = np.sqrt(-2.0 * np.log(1.0 - p))
+
+    # Rational approximation coefficients
+    c0, c1, c2 = 2.515517, 0.802853, 0.010328
+    d1, d2, d3 = 1.432788, 0.189269, 0.001308
+
+    result = t - (c0 + c1 * t + c2 * t * t) / (1 + d1 * t + d2 * t * t + d3 * t * t * t)
+
+    return result if p > 0.5 else -result

--- a/lazypredict/ts_visualization.py
+++ b/lazypredict/ts_visualization.py
@@ -14,7 +14,6 @@ import pandas as pd
 logger = logging.getLogger("lazypredict")
 
 try:
-    import matplotlib
     import matplotlib.pyplot as plt
 
     _MATPLOTLIB_AVAILABLE = True

--- a/lazypredict/tuning.py
+++ b/lazypredict/tuning.py
@@ -4,16 +4,14 @@ Provides Optuna-based and sklearn-based tuning backends for both
 supervised models and time series forecasters.
 """
 
-import copy
 import logging
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
-import numpy as np
 import pandas as pd
 from sklearn.model_selection import RandomizedSearchCV, cross_val_score
 
-from lazypredict.search_spaces import SEARCH_SPACES, get_search_space
+from lazypredict.search_spaces import get_search_space
 
 logger = logging.getLogger("lazypredict")
 
@@ -28,7 +26,7 @@ except ImportError:
 
 # Optional FLAML
 try:
-    from flaml import tune as flaml_tune
+    import flaml.tune  # noqa: F401
 
     _FLAML_AVAILABLE = True
 except ImportError:
@@ -139,7 +137,6 @@ def tune_supervised_sklearn(
 
     Uses a simple parameter distribution derived from the search space registry.
     """
-    from scipy import stats
     from sklearn.pipeline import Pipeline
 
     space_fn = get_search_space(model_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lazypredict"
-version = "0.3.0a4"
+version = "0.3.0a5"
 description = "Lazy Predict helps build a lot of basic models without much code and helps understand which models work better without any parameter tuning"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ foundation = [
 tune = [
     "optuna>=3.0",
 ]
+viz = [
+    "matplotlib>=3.5",
+]
 explain = [
     "shap>=0.42",
 ]
@@ -79,6 +82,7 @@ all = [
     "optuna>=3.0",
     "shap>=0.42",
     "interpret>=0.4",
+    "matplotlib>=3.5",
 ]
 dev = [
     "pytest>=7",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,10 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # sha256 must be updated when a new release is published to PyPI.
-  # Run:  curl -sL https://pypi.org/pypi/lazypredict/<version>/json | python -c "import sys,json; print(json.load(sys.stdin)['urls'][1]['digests']['sha256'])"
-  # sha256: <UPDATE_ON_RELEASE>
+  path: ..
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lazypredict" %}
-{% set version = "0.3.0a4" %}
+{% set version = "0.3.0a5" %}
 
 package:
   name: {{ name|lower }}

--- a/tests/test_categorical_encoder.py
+++ b/tests/test_categorical_encoder.py
@@ -26,7 +26,7 @@ def create_mixed_dataset():
     X_df['cat_low_2'] = np.random.choice(['X', 'Y'], size=200)
 
     # Add high cardinality categorical feature
-    X_df['cat_high'] = [f'cat_{i%50}' for i in range(200)]
+    X_df['cat_high'] = [f'cat_{i % 50}' for i in range(200)]
 
     return X_df, y
 

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -571,3 +571,291 @@ class TestTimesFMForecaster:
         )
         scores, _ = forecaster.fit(y_train, y_test)
         assert len(scores) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Predictions storage bug fix tests
+# ---------------------------------------------------------------------------
+
+class TestPredictionsStorage:
+    def test_predictions_stored_internally_without_flag(self, univariate_data):
+        """Predictions should always be stored internally even with predictions=False."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(
+            predictions=False,
+            forecasters=["Naive", "Ridge_TS"],
+        )
+        scores, preds = forecaster.fit(y_train, y_test)
+        # Return value should be empty (API contract)
+        assert preds.empty
+        # But internal storage should have predictions
+        assert len(forecaster._last_predictions) >= 1
+        for name, y_pred in forecaster._last_predictions.items():
+            assert len(y_pred) == len(y_test)
+
+    def test_predictions_stored_with_flag(self, univariate_data):
+        """With predictions=True, both return value and internal storage populated."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(
+            predictions=True,
+            forecasters=["Naive", "Ridge_TS"],
+        )
+        scores, preds = forecaster.fit(y_train, y_test)
+        assert not preds.empty
+        assert len(forecaster._last_predictions) >= 1
+
+    def test_y_test_stored(self, univariate_data):
+        """y_test should be stored internally for plot/diagnose access."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(forecasters=["Naive"])
+        forecaster.fit(y_train, y_test)
+        np.testing.assert_array_equal(forecaster._last_y_test, y_test)
+
+    def test_scores_stored(self, univariate_data):
+        """Scores DataFrame should be stored internally."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(forecasters=["Naive"])
+        scores, _ = forecaster.fit(y_train, y_test)
+        assert forecaster._last_scores is not None
+        assert len(forecaster._last_scores) == len(scores)
+
+
+# ---------------------------------------------------------------------------
+# Visualization tests
+# ---------------------------------------------------------------------------
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")  # Non-interactive backend for tests
+    import matplotlib.pyplot as plt
+    _HAS_MATPLOTLIB = True
+except ImportError:
+    _HAS_MATPLOTLIB = False
+
+
+@pytest.mark.skipif(not _HAS_MATPLOTLIB, reason="matplotlib not installed")
+class TestVisualization:
+    def _fit_forecaster(self, univariate_data):
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(
+            predictions=True,
+            forecasters=["Naive", "Ridge_TS"],
+        )
+        scores, preds = forecaster.fit(y_train, y_test)
+        return forecaster, y_train, y_test, scores
+
+    def test_plot_forecast_single(self, univariate_data):
+        from lazypredict.ts_visualization import plot_forecast
+        y_train, y_test = univariate_data
+        y_pred = np.full(len(y_test), y_train[-1])
+        fig = plot_forecast(y_train, y_test, y_pred)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_forecast_multiple(self, univariate_data):
+        from lazypredict.ts_visualization import plot_forecast
+        y_train, y_test = univariate_data
+        predictions = {
+            "Model_A": np.full(len(y_test), y_train[-1]),
+            "Model_B": np.full(len(y_test), np.mean(y_train)),
+        }
+        fig = plot_forecast(y_train, y_test, predictions)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_model_comparison(self, univariate_data):
+        from lazypredict.ts_visualization import plot_model_comparison
+        forecaster, y_train, y_test, scores = self._fit_forecaster(univariate_data)
+        fig = plot_model_comparison(scores, metric="RMSE")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_residuals(self, univariate_data):
+        from lazypredict.ts_visualization import plot_residuals
+        y_train, y_test = univariate_data
+        y_pred = np.full(len(y_test), y_train[-1])
+        fig = plot_residuals(y_test, y_pred, model_name="Naive")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_error_distribution(self, univariate_data):
+        from lazypredict.ts_visualization import plot_error_distribution
+        y_train, y_test = univariate_data
+        predictions = {
+            "Model_A": np.full(len(y_test), y_train[-1]),
+            "Model_B": np.full(len(y_test), np.mean(y_train)),
+        }
+        fig = plot_error_distribution(y_test, predictions)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_plot_metrics_heatmap(self, univariate_data):
+        from lazypredict.ts_visualization import plot_metrics_heatmap
+        forecaster, y_train, y_test, scores = self._fit_forecaster(univariate_data)
+        fig = plot_metrics_heatmap(scores)
+        assert fig is not None
+        plt.close(fig)
+
+    def test_lazy_forecaster_plot_results_forecast(self, univariate_data):
+        forecaster, y_train, y_test, scores = self._fit_forecaster(univariate_data)
+        fig = forecaster.plot_results(plot_type="forecast")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_lazy_forecaster_plot_results_comparison(self, univariate_data):
+        forecaster, y_train, y_test, scores = self._fit_forecaster(univariate_data)
+        fig = forecaster.plot_results(plot_type="comparison")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_lazy_forecaster_plot_results_residuals(self, univariate_data):
+        forecaster, y_train, y_test, scores = self._fit_forecaster(univariate_data)
+        fig = forecaster.plot_results(plot_type="residuals", model_name="Naive")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_lazy_forecaster_plot_results_errors(self, univariate_data):
+        forecaster, y_train, y_test, scores = self._fit_forecaster(univariate_data)
+        fig = forecaster.plot_results(plot_type="errors")
+        assert fig is not None
+        plt.close(fig)
+
+    def test_lazy_forecaster_plot_results_heatmap(self, univariate_data):
+        forecaster, y_train, y_test, scores = self._fit_forecaster(univariate_data)
+        fig = forecaster.plot_results(plot_type="heatmap")
+        assert fig is not None
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics tests
+# ---------------------------------------------------------------------------
+
+class TestDiagnostics:
+    def test_residual_diagnostics_keys(self):
+        from lazypredict.ts_diagnostics import residual_diagnostics
+        y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+        y_pred = np.array([1.1, 1.9, 3.2, 3.8, 5.1, 5.9, 7.2, 7.8, 9.1, 9.9])
+        result = residual_diagnostics(y_true, y_pred)
+        expected_keys = {
+            "residuals", "mean", "std",
+            "ljung_box_stat", "ljung_box_pvalue",
+            "jarque_bera_stat", "jarque_bera_pvalue",
+            "acf_values", "is_white_noise", "is_normal",
+        }
+        assert set(result.keys()) == expected_keys
+
+    def test_residuals_computed_correctly(self):
+        from lazypredict.ts_diagnostics import residual_diagnostics
+        y_true = np.array([10.0, 20.0, 30.0])
+        y_pred = np.array([12.0, 18.0, 33.0])
+        result = residual_diagnostics(y_true, y_pred)
+        np.testing.assert_array_almost_equal(result["residuals"], [-2.0, 2.0, -3.0])
+
+    def test_white_noise_detection(self):
+        from lazypredict.ts_diagnostics import residual_diagnostics
+        np.random.seed(42)
+        y_true = np.random.randn(100)
+        y_pred = np.zeros(100)  # residuals = y_true = white noise
+        result = residual_diagnostics(y_true, y_pred)
+        # White noise residuals should pass Ljung-Box (if statsmodels available)
+        if result["ljung_box_pvalue"] is not None:
+            assert result["is_white_noise"] is True
+
+    def test_biased_residuals_mean(self):
+        from lazypredict.ts_diagnostics import residual_diagnostics
+        y_true = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        y_pred = np.array([5.0, 15.0, 25.0, 35.0, 45.0])  # systematic under-prediction
+        result = residual_diagnostics(y_true, y_pred)
+        assert result["mean"] == 5.0  # all residuals are +5
+
+    def test_compare_diagnostics(self, univariate_data):
+        from lazypredict.ts_diagnostics import compare_diagnostics
+        y_train, y_test = univariate_data
+        predictions = {
+            "Model_A": np.full(len(y_test), y_train[-1]),
+            "Model_B": np.full(len(y_test), np.mean(y_train)),
+        }
+        result = compare_diagnostics(y_test, predictions)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 2
+        assert "Model_A" in result.index
+        assert "Model_B" in result.index
+        assert "Residual Mean" in result.columns
+        assert "White Noise" in result.columns
+
+    def test_lazy_forecaster_diagnose_single(self, univariate_data):
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(forecasters=["Naive", "Ridge_TS"])
+        forecaster.fit(y_train, y_test)
+        result = forecaster.diagnose(model_name="Naive")
+        assert isinstance(result, dict)
+        assert "residuals" in result
+        assert "mean" in result
+
+    def test_lazy_forecaster_diagnose_all(self, univariate_data):
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(forecasters=["Naive", "Ridge_TS"])
+        forecaster.fit(y_train, y_test)
+        result = forecaster.diagnose()
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tuning refit tests
+# ---------------------------------------------------------------------------
+
+try:
+    import optuna  # noqa: F401
+    _HAS_OPTUNA = True
+except ImportError:
+    _HAS_OPTUNA = False
+
+
+@pytest.mark.skipif(not _HAS_OPTUNA, reason="optuna not installed")
+class TestTuningRefit:
+    def test_tune_top_k_returns_tuned_models(self, univariate_data):
+        from lazypredict.ts_tuning import tune_top_k_forecasters
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(
+            forecasters=["Ridge_TS"],
+        )
+        scores, _ = forecaster.fit(y_train, y_test)
+        tune_results, tuned_models = tune_top_k_forecasters(
+            scores_df=scores,
+            models=forecaster.models,
+            all_wrappers=forecaster._last_all_forecasters,
+            y_train=y_train,
+            X_train=None,
+            seasonal_period=None,
+            top_k=1,
+            n_trials=3,
+            refit=True,
+        )
+        assert isinstance(tune_results, pd.DataFrame)
+        assert isinstance(tuned_models, dict)
+        # Ridge_TS should be refit
+        if "Ridge_TS" in tuned_models:
+            assert tuned_models["Ridge_TS"] is not None
+
+    def test_tune_top_k_no_refit(self, univariate_data):
+        from lazypredict.ts_tuning import tune_top_k_forecasters
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(
+            forecasters=["Ridge_TS"],
+        )
+        scores, _ = forecaster.fit(y_train, y_test)
+        tune_results, tuned_models = tune_top_k_forecasters(
+            scores_df=scores,
+            models=forecaster.models,
+            all_wrappers=forecaster._last_all_forecasters,
+            y_train=y_train,
+            X_train=None,
+            seasonal_period=None,
+            top_k=1,
+            n_trials=3,
+            refit=False,
+        )
+        assert isinstance(tune_results, pd.DataFrame)
+        assert len(tuned_models) == 0

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -859,3 +859,146 @@ class TestTuningRefit:
         )
         assert isinstance(tune_results, pd.DataFrame)
         assert len(tuned_models) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for refactored LazyForecaster methods
+# ---------------------------------------------------------------------------
+
+
+class TestLazyForecasterRefactoredMethods:
+    """Test the refactored private methods in LazyForecaster."""
+
+    def test_convert_and_validate_inputs(self, univariate_data):
+        """Test input conversion and validation."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(forecasters=["Naive"])
+        y_tr, y_te, X_tr, X_te = forecaster._convert_and_validate_inputs(
+            y_train, y_test, None, None
+        )
+        assert isinstance(y_tr, np.ndarray)
+        assert isinstance(y_te, np.ndarray)
+
+    def test_resolve_seasonal_period_none(self, univariate_data):
+        """Test seasonal period resolution when not specified."""
+        y_train, _ = univariate_data
+        forecaster = LazyForecaster(seasonal_period=None)
+        sp = forecaster._resolve_seasonal_period(y_train)
+        assert isinstance(sp, (int, type(None)))
+
+    def test_resolve_seasonal_period_specified(self, seasonal_data):
+        """Test seasonal period when explicitly specified."""
+        y_train, _ = seasonal_data
+        forecaster = LazyForecaster(seasonal_period=12)
+        sp = forecaster._resolve_seasonal_period(y_train)
+        assert sp == 12
+
+    def test_resolve_forecasters_all(self, univariate_data):
+        """Test forecaster resolution with 'all' keyword."""
+        y_train, _ = univariate_data
+        forecaster = LazyForecaster(forecasters="all", max_models=2)
+        all_forecasters = forecaster._resolve_forecasters(None)
+        assert len(all_forecasters) == 2
+
+    def test_resolve_forecasters_subset(self, univariate_data):
+        """Test forecaster resolution with specific subset."""
+        y_train, _ = univariate_data
+        forecaster = LazyForecaster(forecasters=["Naive", "SeasonalNaive"])
+        all_forecasters = forecaster._resolve_forecasters(None)
+        names = [name for name, _ in all_forecasters]
+        assert set(names) <= {"Naive", "SeasonalNaive"}
+
+    def test_store_fit_state(self, univariate_data):
+        """Test storage of fit state."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(forecasters=["Naive"])
+        scores, _ = forecaster.fit(y_train, y_test)
+
+        assert hasattr(forecaster, "_last_y_train")
+        assert hasattr(forecaster, "_last_y_test")
+        assert hasattr(forecaster, "_last_scores")
+        assert len(forecaster._last_scores) > 0
+
+    def test_plot_results_dispatch(self, univariate_data):
+        """Test plot_results dispatcher."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(forecasters=["Naive"], predictions=True)
+        scores, preds = forecaster.fit(y_train, y_test)
+
+        # Test that dispatcher works with dispatch pattern
+        try:
+            fig = forecaster.plot_results(plot_type="forecast")
+            assert fig is not None
+        except (ImportError, ValueError):
+            # OK if matplotlib not available
+            pass
+
+    def test_ensemble_dispatch_simple_average(self, univariate_data):
+        """Test ensemble dispatcher with simple_average."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(
+            forecasters=["Naive", "SeasonalNaive"],
+            predictions=True,
+        )
+        scores, preds = forecaster.fit(y_train, y_test)
+
+        ens_pred = forecaster.ensemble(method="simple_average")
+        assert len(ens_pred) == len(y_test)
+
+    def test_ensemble_dispatch_weighted_average(self, univariate_data):
+        """Test ensemble dispatcher with weighted_average."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(
+            forecasters=["Naive", "SeasonalNaive"],
+            predictions=True,
+        )
+        scores, preds = forecaster.fit(y_train, y_test)
+
+        ens_pred = forecaster.ensemble(method="weighted_average")
+        assert len(ens_pred) == len(y_test)
+
+    def test_ensemble_dispatch_stacking(self, univariate_data):
+        """Test ensemble dispatcher with stacking."""
+        y_train, y_test = univariate_data
+        forecaster = LazyForecaster(
+            forecasters=["Naive", "SeasonalNaive"],
+            predictions=True,
+        )
+        scores, preds = forecaster.fit(y_train, y_test)
+
+        ens_pred = forecaster.ensemble(method="stacking", y_true=y_test)
+        assert len(ens_pred) == len(y_test)
+
+
+# ---------------------------------------------------------------------------
+# Tests for diagnostics edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsEdgeCases:
+    """Test edge cases in residual diagnostics."""
+
+    def test_diagnostics_small_sample(self):
+        """Test with small sample size."""
+        from lazypredict.ts_diagnostics import residual_diagnostics
+        y_true = np.array([1.0, 2.0, 3.0])
+        y_pred = np.array([1.1, 2.0, 2.9])
+        result = residual_diagnostics(y_true, y_pred)
+        assert "residuals" in result
+        assert result["ljung_box_pvalue"] is None  # Too small for LB test
+
+    def test_diagnostics_zero_variance(self):
+        """Test with zero variance residuals."""
+        from lazypredict.ts_diagnostics import residual_diagnostics
+        y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        y_pred = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = residual_diagnostics(y_true, y_pred)
+        assert result["std"] == 0.0
+
+    def test_compute_acf_numpy_fallback(self):
+        """Test ACF computation with numpy fallback."""
+        from lazypredict.ts_diagnostics import _compute_acf_numpy
+        residuals = np.random.randn(50)
+        acf = _compute_acf_numpy(residuals, max_lag=10)
+        assert len(acf) == 11
+        np.testing.assert_allclose(acf[0], 1.0, rtol=1e-10)  # ACF at lag 0 is always 1


### PR DESCRIPTION
## Summary
This PR introduces comprehensive visualization and residual diagnostics capabilities for time series forecasting. It adds two new modules (`ts_visualization.py` and `ts_diagnostics.py`), integrates them into `LazyForecaster`, and fixes a bug where predictions were not stored internally when `predictions=False`.

## Key Changes

### New Modules
- **`ts_visualization.py`** (427 lines): Plotting utilities for forecast analysis
  - `plot_forecast()`: Overlay actual vs predicted values with training context
  - `plot_model_comparison()`: Horizontal bar chart comparing models by metric
  - `plot_residuals()`: Four-panel diagnostic plot (time series, histogram, Q-Q, ACF)
  - `plot_error_distribution()`: Box plot of absolute errors across models
  - `plot_metrics_heatmap()`: Normalized metrics heatmap for visual comparison
  - Graceful matplotlib dependency handling with optional import

- **`ts_diagnostics.py`** (188 lines): Statistical residual analysis
  - `residual_diagnostics()`: Comprehensive diagnostics including Ljung-Box test, Jarque-Bera test, ACF computation
  - `compare_diagnostics()`: Run diagnostics across multiple models, return DataFrame
  - Fallback implementations when statsmodels unavailable
  - Returns white noise and normality test results

### LazyForecaster Enhancements
- **Bug Fix**: Predictions are now always stored internally (`_last_predictions`) regardless of the `predictions` flag, enabling ensemble/plotting/diagnostics access
- **New Storage**: Added `_last_y_test`, `_last_scores`, and `tuned_models_` attributes for post-fit analysis
- **`plot_results()` Method**: Unified interface for generating visualizations
  - Supports plot types: `'forecast'`, `'comparison'`, `'residuals'`, `'errors'`, `'heatmap'`
  - Reuses stored data from `fit()` if not explicitly provided
  - Flexible kwargs for customization (figsize, metric, model_name, etc.)
- **`diagnose()` Method**: Run residual diagnostics on fitted models
  - Single model returns diagnostic dict
  - All models returns DataFrame with statistical summaries
- **Tuning Integration**: `tune_top_k_forecasters()` now returns both results DataFrame and refitted model wrappers when `refit=True`

### Testing
- Added 30+ new tests covering:
  - Predictions storage behavior with/without flag
  - All visualization functions (single/multiple models)
  - Residual diagnostics (white noise, normality, bias detection)
  - Model comparison diagnostics
  - LazyForecaster integration (plot_results, diagnose methods)
  - Tuning with refit functionality
  - Proper matplotlib backend handling for CI environments

### Implementation Details
- Matplotlib is an optional dependency; functions raise informative ImportError if unavailable
- ACF and normal quantile functions have numpy-only fallbacks for statsmodels unavailability
- Residual diagnostics gracefully degrade: returns None for unavailable statistics rather than failing
- All visualization functions support custom axes for subplot integration
- Version bumped to 0.3.0a5

https://claude.ai/code/session_015gpcv4dEhWn87hHnBQQtiN