### PR TITLE
chore: synchronize conda metadata, harden docs CI, and close audit issues

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,10 +5,6 @@ tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = {major}.{minor}.{patch}
 
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"
 replace = version = "{new_version}"
@@ -18,5 +14,9 @@ search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
 [bumpversion:file:recipe/meta.yaml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:lazypredict/meta.yaml]
 search = version = "{current_version}"
 replace = version = "{new_version}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/ISSUE_CLOSURE_REPORT.md
+++ b/ISSUE_CLOSURE_REPORT.md
@@ -1,0 +1,47 @@
+# Reported Issues Closure Report
+
+**Date:** 2026-03-22
+**Scope reviewed:**
+- `LIBRARY_AUDIT_AND_IMPROVEMENT_PLAN.md` (47 issues)
+- `CICD_PIPELINE_AUDIT_AND_PLAN.md` (30 issues)
+
+## Executive result
+
+Most previously reported issues are already implemented in the current branch via the v0.3.0 refactor. Remaining items are primarily governance/platform items that cannot be enforced from repository code alone (e.g., GitHub branch protection settings).
+
+## Library audit (47 issues) — status
+
+| Audit area | Status | Notes |
+|---|---|---|
+| Monolithic architecture / duplication | ✅ Implemented | Logic is split across `_base.py`, `preprocessing.py`, `metrics.py`, `tuning.py`, and dedicated forecasting modules. |
+| Public API exports | ✅ Implemented | `__all__` is now explicitly defined in `lazypredict/__init__.py`. |
+| Optional integrations separation | ✅ Implemented | Integrations live in `lazypredict/integrations/` and optional feature modules are separated. |
+| Type hints / modernized API surface | ✅ Implemented (substantial) | Core modules now include typed signatures and typed helper functions. |
+| Timeout/error robustness | ✅ Implemented (substantial) | Custom exception module and improved flow control are present (`exceptions.py`, refactored estimator flow). |
+| Global state mutation concerns | ✅ Implemented | Prior global display/warning side effects from old monolithic implementation are no longer used in the refactored architecture. |
+| Test architecture | ✅ Implemented (substantial) | Tests cover supervised, multiclass, timeseries, config, CLI, and new features. |
+
+## CI/CD audit (30 issues) — status
+
+| Audit area | Status | Notes |
+|---|---|---|
+| CI quality gates (`pytest || true`) | ✅ Implemented | Tests now fail CI correctly. |
+| Publish gated by tests | ✅ Implemented | `publish.yml` includes a pre-publish test job gate. |
+| Outdated actions | ✅ Implemented | Workflows use `actions/checkout@v4` and `actions/setup-python@v5`. |
+| CodeQL outdated | ✅ Implemented | Uses `github/codeql-action@v3` and scans `dev` + `master`. |
+| Docs deployment safety | ✅ Implemented | Deploy is push-to-master only; additionally now skips draft PR builds. |
+| Version source drift | ✅ Implemented | Versioning remains source-driven (`pyproject.toml` / `__init__.py`) and recipe references updated. |
+| Conda metadata mismatch | ✅ Implemented (this change) | `lazypredict/meta.yaml` updated to `0.3.0`. |
+| bumpversion mis-targeting setup.py | ✅ Implemented (this change) | Removed stale setup.py target and added `lazypredict/meta.yaml` mapping. |
+| Branch protection policy docs | ⚠️ Not required in-code | Must be configured in GitHub repository settings (outside this codebase). |
+
+## Actions taken in this change
+
+1. Updated stale conda metadata version in `lazypredict/meta.yaml` from `0.2.16` to `0.3.0`.
+2. Updated `.bumpversion.cfg` to remove obsolete `setup.py` replacement and track `lazypredict/meta.yaml`.
+3. Hardened docs workflow to skip draft PR runs (`if: github.event_name == 'push' || github.event.pull_request.draft == false`).
+
+## Closeability guidance
+
+- **Closable now:** repository-code issues listed as implemented above.
+- **Not code-closeable here:** branch protection / review policy issues (must be handled in GitHub settings).

--- a/lazypredict/meta.yaml
+++ b/lazypredict/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lazypredict" %}
-{% set version = "0.2.16" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
### Motivation
- Resolve version-drift between package source and conda recipe so metadata remains consistent across packaging artifacts. 
- Close and track outstanding audit findings from the library and CI/CD audits by recording status and applying small repository fixes. 
- Reduce unnecessary CI churn by preventing docs workflow runs for draft PRs while keeping push and merged-docs behavior unchanged. 

### Description
- Update the conda recipe version by setting `lazypredict/meta.yaml` to `0.3.0` to match the source version. 
- Modify `.bumpversion.cfg` to remove the obsolete `setup.py` target and add `lazypredict/meta.yaml` so automated bumps update the recipe as well. 
- Harden the documentation workflow by adding `if: github.event_name == 'push' || github.event.pull_request.draft == false` to ` .github/workflows/docs.yml` to skip draft PR builds. 
- Add `ISSUE_CLOSURE_REPORT.md` that summarizes the audit findings, marks which issues are implemented in the refactor, and lists remaining non-code (repository settings) items. 

### Testing
- Ran the full test suite with `pytest -q`, which completed successfully with `190 passed, 21 skipped` and no test failures. 
- Verified repository changes are limited to metadata and CI workflow guards and did not introduce test regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c020fdc7a48327b5bc9bdebd7b8726)