### PR TITLE
Fix string name filtering for classifiers/regressors and add Python 3…

### DIFF
--- a/lazypredict/Supervised.py
+++ b/lazypredict/Supervised.py
@@ -297,6 +297,13 @@ class LazyClassifier(LazyEstimator):
     def _get_estimator_list(self) -> List[Tuple[str, Any]]:
         if self.classifiers == "all":
             return list(CLASSIFIERS)
+        # Support both string names and class objects
+        if self.classifiers and isinstance(self.classifiers[0], str):
+            return [
+                (name, cls)
+                for name, cls in CLASSIFIERS
+                if name in self.classifiers
+            ]
         try:
             return [(cls.__name__, cls) for cls in self.classifiers]
         except Exception as exc:
@@ -538,6 +545,13 @@ class LazyRegressor(LazyEstimator):
     def _get_estimator_list(self) -> List[Tuple[str, Any]]:
         if self.regressors == "all":
             return list(REGRESSORS)
+        # Support both string names and class objects
+        if self.regressors and isinstance(self.regressors[0], str):
+            return [
+                (name, cls)
+                for name, cls in REGRESSORS
+                if name in self.regressors
+            ]
         try:
             return [(cls.__name__, cls) for cls in self.regressors]
         except Exception as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "click",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ xgboost>=1.5
 lightgbm>=3.0
 statsmodels>=0.13
 pmdarima>=2.0
+optuna>=3.0


### PR DESCRIPTION
….14 support

Support passing model names as strings (e.g. ["Lasso", "Ridge"]) to the classifiers/regressors parameters of LazyClassifier/LazyRegressor, which previously raised ValueError due to attempting to unpack strings as tuples. Also add Python 3.14 classifier to pyproject.toml.

Fixes #545, closes #544

https://claude.ai/code/session_011otZcy3oKwvaJqyUQWuj8H