### PR TITLE
Deploy docs to GitHub Pages on push to dev

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,7 +70,7 @@ jobs:
           action: auto
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev')
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- The Material for MkDocs migration is on `dev` (merged in #570), but the
  live GitHub Pages site is still the old Sphinx build because the `deploy`
  job only fires on `push` to `master`.
- This PR lets `deploy` also run on `push` to `dev`, so the new docs go
  live immediately — without waiting for a future `dev` → `master` merge.
- `clean-exclude: pr-preview/**` is preserved so active PR previews are
  not wiped when the main site publishes.

Once this PR merges to `dev`, the `deploy` job will run on that push and
publish the Material for MkDocs site to `https://shankarpandala.github.io/lazypredict/`.

## Test plan

- [x] `mkdocs build --strict` passed on the previous commit (run #134)
- [ ] `Documentation / build` passes on this PR
- [ ] After merge: `Documentation / deploy` runs on the push to `dev`
- [ ] GitHub Pages serves the new Material theme (no more Sphinx footer)
- [ ] Active PR previews under `pr-preview/**` still resolve after the deploy

https://claude.ai/code/session_01PPFXeXQz8Jvmk5g8rHHChr

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFXeXQz8Jvmk5g8rHHChr)_